### PR TITLE
feat: refactor database schema references from DB.Schema to DB.Tables

### DIFF
--- a/src/api/utils/api-res.ts
+++ b/src/api/utils/api-res.ts
@@ -1,4 +1,4 @@
-import type { Context } from "hono";
+import { type Context } from "hono";
 import { z } from "zod";
 
 export class APIResponse {
@@ -30,6 +30,9 @@ export class APIResponse {
 
     static unauthorized(c: Context, message: string) {
         return c.json({ success: false, code: 401, message }, 401);
+    }
+    static forbidden(c: Context, message: string) {
+        return c.json({ success: false, code: 403, message }, 403);
     }
 
     static badRequest(c: Context, message: string) {
@@ -99,6 +102,7 @@ export namespace APIResponse.Schema {
 
     export const serverError = APIResponse.Utils.createErrorSchemaFactory(500);
     export const unauthorized = APIResponse.Utils.createErrorSchemaFactory(401);
+    export const forbidden = APIResponse.Utils.createErrorSchemaFactory(403);
     export const badRequest = APIResponse.Utils.createErrorSchemaFactory(400);
     export const notFound = APIResponse.Utils.createErrorSchemaFactory(404);
     export const conflict = APIResponse.Utils.createErrorSchemaFactory(409);
@@ -112,12 +116,25 @@ export namespace APIResponse.Types {
 
     export type NonRequiredReturnData = null | RequiredReturnData;
 
+    export type BasicReturnData = 
+        | ReturnType<typeof APIResponse.success>
+        | ReturnType<typeof APIResponse.accepted>
+        | ReturnType<typeof APIResponse.created>
+        | ReturnType<typeof APIResponse.serverError>
+        | ReturnType<typeof APIResponse.unauthorized>
+        | ReturnType<typeof APIResponse.forbidden>
+        | ReturnType<typeof APIResponse.badRequest>
+        | ReturnType<typeof APIResponse.notFound>
+        | ReturnType<typeof APIResponse.conflict>
+        | ReturnType<typeof APIResponse.tooManyRequests>;
+
     export type BasicResponseSchema =
         | z.infer<ReturnType<typeof APIResponse.Schema.success<any, z.ZodType<NonRequiredReturnData>>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.accepted<any, z.ZodType<RequiredReturnData>>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.created<any, z.ZodType<RequiredReturnData>>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.serverError<any>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.unauthorized<any>>>
+        | z.infer<ReturnType<typeof APIResponse.Schema.forbidden<any>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.badRequest<any>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.notFound<any>>>
         | z.infer<ReturnType<typeof APIResponse.Schema.conflict<any>>>

--- a/src/api/utils/authHandler.ts
+++ b/src/api/utils/authHandler.ts
@@ -7,7 +7,7 @@ import type { UserAccountSettings } from "./shared-models/accountData";
 export class AuthUtils {
 
     static async getUserRole(userID: number) {
-        const user = DB.instance().select().from(DB.Schema.users).where(eq(DB.Schema.users.id, userID)).get();
+        const user = DB.instance().select().from(DB.Tables.users).where(eq(DB.Tables.users.id, userID)).get();
         if (!user) {
             return null;
         }
@@ -73,7 +73,7 @@ export class SessionHandler {
             tokenBase
         );
 
-        const result = await DB.instance().insert(DB.Schema.sessions).values({
+        const result = await DB.instance().insert(DB.Tables.sessions).values({
             id: tokenID,
             hashed_token: await AuthUtils.hashTokenBase(tokenBase),
             user_id: userID,
@@ -96,8 +96,8 @@ export class SessionHandler {
             return null;
         }
 
-        const session = DB.instance().select().from(DB.Schema.sessions).where(
-            eq(DB.Schema.sessions.id, tokenParts.id)
+        const session = DB.instance().select().from(DB.Tables.sessions).where(
+            eq(DB.Tables.sessions.id, tokenParts.id)
         ).get();
         if (!session) {
             return null;
@@ -117,7 +117,7 @@ export class SessionHandler {
 
         if (session.expires_at < Date.now()) {
             // Delete expired session
-            await DB.instance().delete(DB.Schema.sessions).where(eq(DB.Schema.sessions.id, session.id));
+            await DB.instance().delete(DB.Tables.sessions).where(eq(DB.Tables.sessions.id, session.id));
 
             return false;
         }
@@ -126,18 +126,18 @@ export class SessionHandler {
     }
         
     static async inValidateAllSessionsForUser(userID: number) {
-        await DB.instance().delete(DB.Schema.sessions).where(eq(DB.Schema.sessions.user_id, userID));
+        await DB.instance().delete(DB.Tables.sessions).where(eq(DB.Tables.sessions.user_id, userID));
     }
 
     static async inValidateSession(tokenID: string) {
-        await DB.instance().delete(DB.Schema.sessions).where(eq(DB.Schema.sessions.id, tokenID));
+        await DB.instance().delete(DB.Tables.sessions).where(eq(DB.Tables.sessions.id, tokenID));
     }
 
     static async changeUserRoleInSessions(userID: number, newRole: UserAccountSettings.Role) {
-        await DB.instance().update(DB.Schema.sessions).set({
+        await DB.instance().update(DB.Tables.sessions).set({
             user_role: newRole
         }).where(
-            eq(DB.Schema.sessions.user_id, userID)
+            eq(DB.Tables.sessions.user_id, userID)
         )
     }
 
@@ -159,7 +159,7 @@ export class APIKeyHandler {
             tokenBase
         );
 
-        const result = await DB.instance().insert(DB.Schema.apiKeys).values({
+        const result = await DB.instance().insert(DB.Tables.apiKeys).values({
             id: tokenID,
             hashed_token: await AuthUtils.hashTokenBase(tokenBase),
             user_id: userID,
@@ -184,8 +184,8 @@ export class APIKeyHandler {
             return null;
         }
 
-        const key = DB.instance().select().from(DB.Schema.apiKeys).where(
-            eq(DB.Schema.apiKeys.id, tokenParts.id)
+        const key = DB.instance().select().from(DB.Tables.apiKeys).where(
+            eq(DB.Tables.apiKeys.id, tokenParts.id)
         ).get();
 
         if (!key) {
@@ -212,18 +212,18 @@ export class APIKeyHandler {
     }
 
     static async deleteAllApiKeysForUser(userID: number) {
-        await DB.instance().delete(DB.Schema.apiKeys).where(eq(DB.Schema.apiKeys.user_id, userID));
+        await DB.instance().delete(DB.Tables.apiKeys).where(eq(DB.Tables.apiKeys.user_id, userID));
     }
 
     static async deleteApiKey(apiKeyID: string) {
-        await DB.instance().delete(DB.Schema.apiKeys).where(eq(DB.Schema.apiKeys.id, apiKeyID));
+        await DB.instance().delete(DB.Tables.apiKeys).where(eq(DB.Tables.apiKeys.id, apiKeyID));
     }
 
     static async changeUserRoleInApiKeys(userID: number, newRole: UserAccountSettings.Role) {
-        await DB.instance().update(DB.Schema.apiKeys).set({
+        await DB.instance().update(DB.Tables.apiKeys).set({
             user_role: newRole
         }).where(
-            eq(DB.Schema.apiKeys.user_id, userID)
+            eq(DB.Tables.apiKeys.user_id, userID)
         );
     }
 }
@@ -316,6 +316,10 @@ export namespace AuthHandler {
     export type TOKEN_PREFIX = typeof SessionHandler.SESSION_TOKEN_PREFIX | typeof APIKeyHandler.API_KEY_PREFIX;
 
     export type AuthContext = SessionAuthContext | ApiKeyAuthContext;
+
+    export interface UnauthenticatedAuthContext {
+        readonly type: 'unauthenticated';
+    }
 
     export interface SessionAuthContext extends DB.Models.Session {
         readonly type: 'session';

--- a/src/api/utils/email.ts
+++ b/src/api/utils/email.ts
@@ -1,0 +1,140 @@
+import nodemailer from "nodemailer";
+import type { Transporter } from "nodemailer";
+import { ConfigHandler } from "../../utils/config";
+import { Logger } from "../../utils/logger";
+
+export interface CapturedEmail {
+    from: string;
+    to: string;
+    subject: string;
+    html: string;
+    text: string;
+}
+
+export class EmailService {
+
+    private static transporter: Transporter | null = null;
+    private static enabled = false;
+
+    private static _from: string = "\"Delivr\" <noreply@delivr.email>";
+
+    /**
+     * Initialise the email service from the current config.
+     * Safe to call even when SMTP is unconfigured — logs a warning and disables itself.
+     *
+     * When `testTransport` is provided it is used instead of creating a real SMTP
+     * transport, making the service testable without a live SMTP server.
+     */
+    static init(testTransport?: Transporter) {
+        const config = ConfigHandler.getConfig() as NonNullable<ReturnType<typeof ConfigHandler.getConfig>>;
+        const host = config.DLA_SMTP_HOST;
+
+        if (testTransport) {
+            this.transporter = testTransport;
+            this.enabled = true;
+            if (config.DLA_SMTP_FROM) {
+                this._from = config.DLA_SMTP_FROM;
+            }
+            Logger.log("Email service initialised (test transport)");
+            return;
+        }
+
+        if (!host) {
+            Logger.warn("SMTP not configured — email features disabled");
+            return;
+        }
+
+        try {
+            this.transporter = nodemailer.createTransport({
+                host,
+                port: parseInt(config.DLA_SMTP_PORT ?? "587"),
+                secure: config.DLA_SMTP_SECURE === true,
+                auth: config.DLA_SMTP_USERNAME
+                    ? {
+                        user: config.DLA_SMTP_USERNAME,
+                        pass: config.DLA_SMTP_PASSWORD ?? "",
+                    }
+                    : undefined,
+            });
+
+            if (config.DLA_SMTP_FROM) {
+                this._from = config.DLA_SMTP_FROM;
+            }
+
+            this.enabled = true;
+            Logger.log(`Email service initialised (SMTP ${host}:${config.DLA_SMTP_PORT ?? "587"})`);
+        } catch (err) {
+            Logger.error(`Failed to initialise email service: ${err}`);
+        }
+    }
+
+    /** Reset the service to its unconfigured state (for testing). */
+    static reset() {
+        this.transporter = null;
+        this.enabled = false;
+        this._from = "\"Delivr\" <noreply@delivr.email>";
+    }
+
+    /** Whether the email service is configured and ready. */
+    static isEnabled() {
+        return this.enabled;
+    }
+
+    /** The configured "from" address. */
+    static getFrom(): string {
+        return this._from;
+    }
+
+    /**
+     * Send a password-reset email to a user.
+     *
+     * This is fire-and-forget: errors are logged but never thrown, so callers
+     * should use `.catch()` if they need to react to failures.
+     */
+    static async sendPasswordResetEmail(to: string, rawToken: string) {
+        if (!this.transporter) {
+            Logger.warn("Email service not available — cannot send password reset email");
+            return;
+        }
+
+        const config = ConfigHandler.getConfig() as NonNullable<ReturnType<typeof ConfigHandler.getConfig>>;
+        const appUrl = config.DLA_APP_URL ?? "http://localhost:14128";
+        const resetUrl = `${appUrl}/auth/reset-password?token=${encodeURIComponent(rawToken)}`;
+
+        const html = [
+            "<!DOCTYPE html>",
+            "<html><head><meta charset=\"utf-8\"></head><body>",
+            "<div style=\"max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif\">",
+            "",
+            "  <h2 style=\"color:#1a1a2e\">Password Reset Request</h2>",
+            "",
+            "  <p>We received a request to reset the password for your Delivr account.",
+            "  If you made this request, click the button below to set a new password.</p>",
+            "",
+            `  <a href="${resetUrl}" style="display:inline-block;padding:12px 28px;margin:20px 0;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Reset Password</a>`,
+            "",
+            "  <p style=\"color:#666;font-size:14px\">This link will expire in <strong>1 hour</strong>.</p>",
+            "",
+            "  <hr style=\"border:none;border-top:1px solid #e5e7eb;margin:24px 0\">",
+            "",
+            "  <p style=\"color:#999;font-size:13px\">",
+            "  If you did not request a password reset, you can safely ignore this email.",
+            "  Your account remains secure.</p>",
+            "",
+            "</div>",
+            "</body></html>",
+        ].join("\n");
+
+        try {
+            const info = await this.transporter.sendMail({
+                from: this._from,
+                to,
+                subject: "Delivr — Password Reset Request",
+                html,
+            });
+            Logger.log(`Password reset email sent to ${to} (message-id: ${info.messageId})`);
+        } catch (err) {
+            Logger.error(`Failed to send password reset email to ${to}: ${err}`);
+        }
+    }
+}

--- a/src/api/utils/metadata.ts
+++ b/src/api/utils/metadata.ts
@@ -9,8 +9,8 @@ export class RuntimeMetadata {
     } as const;
 
     protected static async getMetadata<T extends keyof typeof this.schemas>(key: T, createIfNotFound = false): Promise<z.infer<(typeof this.schemas)[T]>> {
-        const record = await DB.instance().select().from(DB.Schema.metadata).where(
-            eq(DB.Schema.metadata.key, key)
+        const record = await DB.instance().select().from(DB.Tables.metadata).where(
+            eq(DB.Tables.metadata.key, key)
         ).get();
 
         if (!record) {
@@ -20,7 +20,7 @@ export class RuntimeMetadata {
             }
 
             const defaultData = this.schemas[key].parse(undefined);
-            await DB.instance().insert(DB.Schema.metadata).values({
+            await DB.instance().insert(DB.Tables.metadata).values({
                 key: key,
                 data: defaultData,
             });
@@ -31,10 +31,10 @@ export class RuntimeMetadata {
     }
 
     protected static async setMetadata<T extends keyof typeof this.schemas>(key: T, data: z.infer<(typeof this.schemas)[T]>): Promise<void> {
-        await DB.instance().update(DB.Schema.metadata).set({
+        await DB.instance().update(DB.Tables.metadata).set({
             data: data,
         }).where(
-            eq(DB.Schema.metadata.key, key)
+            eq(DB.Tables.metadata.key, key)
         );
     }
 

--- a/src/api/utils/preferences.ts
+++ b/src/api/utils/preferences.ts
@@ -31,10 +31,10 @@ export class UserPreferencesHandler {
         key: T
     ): Promise<z.infer<(typeof UserPreferences.schemas)[T]>> {
 
-        const record = await DB.instance().select().from(DB.Schema.userPreferences).where(
+        const record = await DB.instance().select().from(DB.Tables.userPreferences).where(
             and(
-                eq(DB.Schema.userPreferences.user_id, userID),
-                eq(DB.Schema.userPreferences.key, key)
+                eq(DB.Tables.userPreferences.user_id, userID),
+                eq(DB.Tables.userPreferences.key, key)
             )
         ).get();
 
@@ -55,12 +55,12 @@ export class UserPreferencesHandler {
 
         const parsed = UserPreferences.schemas[key].parse(data);
 
-        await DB.instance().insert(DB.Schema.userPreferences).values({
+        await DB.instance().insert(DB.Tables.userPreferences).values({
             user_id: userID,
             key,
             data: parsed
         }).onConflictDoUpdate({
-            target: [DB.Schema.userPreferences.user_id, DB.Schema.userPreferences.key],
+            target: [DB.Tables.userPreferences.user_id, DB.Tables.userPreferences.key],
             set: { data: parsed }
         });
     }
@@ -74,8 +74,8 @@ export class UserPreferencesHandler {
     }
 
     static async deleteAllForUser(userID: number): Promise<void> {
-        await DB.instance().delete(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, userID)
+        await DB.instance().delete(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, userID)
         );
     }
 

--- a/src/api/versions/v1/middleware/auth.ts
+++ b/src/api/versions/v1/middleware/auth.ts
@@ -4,16 +4,19 @@ import { AuthHandler } from '../../../utils/authHandler';
 
 export const authMiddlewareV1 = createMiddleware(async (c, next) => {
 
-    if (
-        c.req.path.startsWith("/v1/auth/login") || c.req.path.startsWith("/v1/auth/signup") ||
-        c.req.path.startsWith("/v1/auth/reset-password")
-    ) {
-        return await next();
-    }
-
     const authHeader = c.req.header("Authorization");
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
+
+        if (
+            c.req.path.startsWith("/v1/auth/login") || c.req.path.startsWith("/v1/auth/signup") ||
+            c.req.path.startsWith("/v1/auth/reset-password")
+        ) {
+            AuthHandler.AuthContext.set(c, { type: 'unauthenticated' } satisfies AuthHandler.UnauthenticatedAuthContext as any);
+
+            return await next();
+        }
+
         return APIResponse.unauthorized(c, "Missing or invalid Authorization header");
     }
 
@@ -22,6 +25,16 @@ export const authMiddlewareV1 = createMiddleware(async (c, next) => {
     const authContext = await AuthHandler.getAuthContext(token);
 
     if (!authContext || !(await AuthHandler.isValidAuthContext(authContext))) {
+
+        if (
+            c.req.path.startsWith("/v1/auth/login") || c.req.path.startsWith("/v1/auth/signup") ||
+            c.req.path.startsWith("/v1/auth/reset-password")
+        ) {
+            AuthHandler.AuthContext.set(c, { type: 'unauthenticated' } satisfies AuthHandler.UnauthenticatedAuthContext as any);
+
+            return await next();
+        }
+
         return APIResponse.unauthorized(c, "Invalid or expired token");
     }
 

--- a/src/api/versions/v1/routes/account/apikeys/index.ts
+++ b/src/api/versions/v1/routes/account/apikeys/index.ts
@@ -28,8 +28,8 @@ router.get('/',
         // @ts-ignore
         const authContext = c.get("authContext") as AuthHandler.SessionAuthContext;
 
-        const apiKeys = DB.instance().select().from(DB.Schema.apiKeys).where(
-            eq(DB.Schema.apiKeys.user_id, authContext.user_id)
+        const apiKeys = DB.instance().select().from(DB.Tables.apiKeys).where(
+            eq(DB.Tables.apiKeys.user_id, authContext.user_id)
         ).all();
 
         const apiKeysWithoutSensitive = apiKeys.map(key => ({
@@ -119,9 +119,9 @@ router.use('/:apiKeyID/*',
         // @ts-ignore
         const apiKeyID = (c.req.valid("param") as { apiKeyID: string }).apiKeyID;
 
-        const apiKey = await DB.instance().select().from(DB.Schema.apiKeys).where(and(
-            eq(DB.Schema.apiKeys.id, apiKeyID),
-            eq(DB.Schema.apiKeys.user_id, authContext.user_id)
+        const apiKey = await DB.instance().select().from(DB.Tables.apiKeys).where(and(
+            eq(DB.Tables.apiKeys.id, apiKeyID),
+            eq(DB.Tables.apiKeys.user_id, authContext.user_id)
         )).get();
 
         if (!apiKey) {

--- a/src/api/versions/v1/routes/account/apikeys/model.ts
+++ b/src/api/versions/v1/routes/account/apikeys/model.ts
@@ -4,7 +4,7 @@ import { DB } from "../../../../../../db";
 
 export namespace AccountAPIKeysModel.GetById {
 
-    export const Response = createSelectSchema(DB.Schema.apiKeys).omit({
+    export const Response = createSelectSchema(DB.Tables.apiKeys).omit({
         user_id: true,
         user_role: true,
         hashed_token: true,
@@ -22,7 +22,7 @@ export namespace AccountAPIKeysModel.GetAll {
 
 export namespace AccountAPIKeysModel.Create {
 
-    export const Body = createInsertSchema(DB.Schema.apiKeys, {
+    export const Body = createInsertSchema(DB.Tables.apiKeys, {
         expires_at: z.union([
             z.literal("7d").meta({ title: "7 days" }),
             z.literal("30d").meta({ title: "30 days" }),

--- a/src/api/versions/v1/routes/account/index.ts
+++ b/src/api/versions/v1/routes/account/index.ts
@@ -42,8 +42,8 @@ router.get('/',
 
         const authContext = AuthHandler.AuthContext.getAsSession(c);
 
-        const user = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.id, authContext.user_id)
+        const user = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.id, authContext.user_id)
         ).get();
 
         if (!user) {
@@ -77,8 +77,8 @@ router.put('/',
 
         const body = c.req.valid("json") as AccountModel.UpdateInfo.Body;
 
-        DB.instance().update(DB.Schema.users).set(body).where(
-            eq(DB.Schema.users.id, authContext.user_id)
+        DB.instance().update(DB.Tables.users).set(body).where(
+            eq(DB.Tables.users.id, authContext.user_id)
         ).run();
 
         return APIResponse.successNoData(c, "Account information updated successfully");
@@ -111,8 +111,8 @@ router.put('/password',
 
         const body = c.req.valid("json")
 
-        const user = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.id, authContext.user_id)
+        const user = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.id, authContext.user_id)
         ).get();
     
         if (!user) {
@@ -125,10 +125,10 @@ router.put('/password',
 
         const newPasswordHash = await Bun.password.hash(body.new_password);
 
-        DB.instance().update(DB.Schema.users).set({
+        DB.instance().update(DB.Tables.users).set({
             password_hash: newPasswordHash
         }).where(
-            eq(DB.Schema.users.id, authContext.user_id)
+            eq(DB.Tables.users.id, authContext.user_id)
         ).run();
 
         await SessionHandler.inValidateAllSessionsForUser(authContext.user_id);
@@ -156,8 +156,8 @@ router.delete('/',
 
         const authContext = AuthHandler.AuthContext.getAsSession(c);
 
-        const mailAccounts = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.owner_user_id, authContext.user_id)
+        const mailAccounts = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.owner_user_id, authContext.user_id)
         ).all();
 
         if (mailAccounts.length > 0) {
@@ -168,16 +168,16 @@ router.delete('/',
         await AuthHandler.invalidateAllAuthContextsForUser(authContext.user_id);
 
         // delete password resets
-        DB.instance().delete(DB.Schema.passwordResets).where(
-            eq(DB.Schema.passwordResets.user_id, authContext.user_id)
+        DB.instance().delete(DB.Tables.passwordResets).where(
+            eq(DB.Tables.passwordResets.user_id, authContext.user_id)
         ).run();
 
         // delete stored preferences
         await UserPreferencesHandler.deleteAllForUser(authContext.user_id);
 
         // finally, delete the user account
-        DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, authContext.user_id)
+        DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, authContext.user_id)
         ).run();
 
         return APIResponse.successNoData(c, "Account deleted successfully");

--- a/src/api/versions/v1/routes/account/model.ts
+++ b/src/api/versions/v1/routes/account/model.ts
@@ -5,7 +5,7 @@ import { UserDataPolicys } from "../../../../utils/shared-models/accountData";
 
 export namespace AccountModel.GetInfo {
 
-    export const Response = createSelectSchema(DB.Schema.users).omit({
+    export const Response = createSelectSchema(DB.Tables.users).omit({
         password_hash: true
     });
     export type Response = z.infer<typeof Response>;
@@ -14,7 +14,7 @@ export namespace AccountModel.GetInfo {
 
 export namespace AccountModel.UpdateInfo {
 
-    export const Body = createUpdateSchema(DB.Schema.users, {
+    export const Body = createUpdateSchema(DB.Tables.users, {
         username: UserDataPolicys.Username,
         email: z.email('Invalid email')
     }).omit({

--- a/src/api/versions/v1/routes/admin/users/index.ts
+++ b/src/api/versions/v1/routes/admin/users/index.ts
@@ -34,21 +34,21 @@ router.get('/',
         let predicate: ReturnType<typeof eq> | undefined;
 
         if (filters.role) {
-            predicate = eq(DB.Schema.users.role, filters.role);
+            predicate = eq(DB.Tables.users.role, filters.role);
         }
 
         if (filters.search) {
             const pattern = `%${filters.search}%`;
             const searchPredicate = or(
-                like(DB.Schema.users.username, pattern),
-                like(DB.Schema.users.display_name, pattern),
-                like(DB.Schema.users.email, pattern),
+                like(DB.Tables.users.username, pattern),
+                like(DB.Tables.users.display_name, pattern),
+                like(DB.Tables.users.email, pattern),
             );
 
             predicate = predicate ? and(predicate, searchPredicate) : searchPredicate;
         }
 
-        let query = DB.instance().select().from(DB.Schema.users).$dynamic();
+        let query = DB.instance().select().from(DB.Tables.users).$dynamic();
 
         if (predicate) {
             query = query.where(predicate);
@@ -62,7 +62,7 @@ router.get('/',
             query = query.offset(filters.offset);
         }
 
-        const users = await query.orderBy(DB.Schema.users.id);
+        const users = await query.orderBy(DB.Tables.users.id);
 
         return APIResponse.success(c, "Users retrieved successfully", users.map(sanitizeUser));
     }
@@ -86,10 +86,10 @@ router.post('/',
     async (c) => {
         const body = c.req.valid("json") as AdminUsersModel.Create.Body;
 
-        const duplicate = DB.instance().select().from(DB.Schema.users).where(
+        const duplicate = DB.instance().select().from(DB.Tables.users).where(
             or(
-                eq(DB.Schema.users.username, body.username),
-                eq(DB.Schema.users.email, body.email)
+                eq(DB.Tables.users.username, body.username),
+                eq(DB.Tables.users.email, body.email)
             )
         ).get();
 
@@ -99,7 +99,7 @@ router.post('/',
 
         const { password, ...userData } = body;
 
-        const createdUser = DB.instance().insert(DB.Schema.users).values({
+        const createdUser = DB.instance().insert(DB.Tables.users).values({
             ...userData,
             password_hash: await Bun.password.hash(password)
         }).returning().get();
@@ -116,8 +116,8 @@ router.use('/:userId/*',
         // @ts-ignore - hono-openapi does not type "param" yet
         const { userId } = c.req.valid("param") as AdminUsersModel.UserId.Params;
 
-        const user = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.id, userId)
+        const user = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.id, userId)
         ).get();
 
         if (!user) {
@@ -181,8 +181,8 @@ router.put('/:userId',
         }
 
         if (updates.username && updates.username !== user.username) {
-            const usernameConflict = DB.instance().select().from(DB.Schema.users).where(
-                eq(DB.Schema.users.username, updates.username)
+            const usernameConflict = DB.instance().select().from(DB.Tables.users).where(
+                eq(DB.Tables.users.username, updates.username)
             ).get();
 
             if (usernameConflict) {
@@ -191,8 +191,8 @@ router.put('/:userId',
         }
 
         if (updates.email && updates.email !== user.email) {
-            const emailConflict = DB.instance().select().from(DB.Schema.users).where(
-                eq(DB.Schema.users.email, updates.email)
+            const emailConflict = DB.instance().select().from(DB.Tables.users).where(
+                eq(DB.Tables.users.email, updates.email)
             ).get();
 
             if (emailConflict) {
@@ -202,16 +202,16 @@ router.put('/:userId',
 
         const roleChanged = updates.role && updates.role !== user.role;
 
-        await DB.instance().update(DB.Schema.users).set(updates).where(
-            eq(DB.Schema.users.id, user.id)
+        await DB.instance().update(DB.Tables.users).set(updates).where(
+            eq(DB.Tables.users.id, user.id)
         ).run();
 
         if (roleChanged && updates.role) {
             await AuthHandler.changeUserRoleInAuthContexts(user.id, updates.role);
         }
 
-        const refreshed = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.id, user.id)
+        const refreshed = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.id, user.id)
         ).get();
 
         if (!refreshed) {
@@ -244,10 +244,10 @@ router.put('/:userId/password',
 
         const passwordHash = await Bun.password.hash(password);
 
-        await DB.instance().update(DB.Schema.users).set({
+        await DB.instance().update(DB.Tables.users).set({
             password_hash: passwordHash
         }).where(
-            eq(DB.Schema.users.id, user.id)
+            eq(DB.Tables.users.id, user.id)
         ).run();
 
         await SessionHandler.inValidateAllSessionsForUser(user.id);
@@ -278,12 +278,12 @@ router.delete('/:userId',
 
         await AuthHandler.invalidateAllAuthContextsForUser(user.id);
 
-        await DB.instance().delete(DB.Schema.passwordResets).where(
-            eq(DB.Schema.passwordResets.user_id, user.id)
+        await DB.instance().delete(DB.Tables.passwordResets).where(
+            eq(DB.Tables.passwordResets.user_id, user.id)
         ).run();
 
-        await DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, user.id)
+        await DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, user.id)
         ).run();
 
         return APIResponse.successNoData(c, "User deleted successfully");

--- a/src/api/versions/v1/routes/admin/users/model.ts
+++ b/src/api/versions/v1/routes/admin/users/model.ts
@@ -5,7 +5,7 @@ import { UserAccountSettings, UserDataPolicys } from "../../../../../utils/share
 
 export namespace AdminUsersModel {
 
-    const BaseUser = createSelectSchema(DB.Schema.users);
+    const BaseUser = createSelectSchema(DB.Tables.users);
 
     export const SafeUser = BaseUser.omit({ password_hash: true });
     export type SafeUser = z.infer<typeof SafeUser>;
@@ -24,7 +24,7 @@ export namespace AdminUsersModel {
     }
 
     export namespace Create {
-        const InsertSchema = createInsertSchema(DB.Schema.users, {
+        const InsertSchema = createInsertSchema(DB.Tables.users, {
             username: UserDataPolicys.Username,
             display_name: z.string().min(1).max(64),
             email: z.email(),
@@ -44,7 +44,7 @@ export namespace AdminUsersModel {
     }
 
     export namespace Update {
-        export const Body = createUpdateSchema(DB.Schema.users).omit({
+        export const Body = createUpdateSchema(DB.Tables.users).omit({
             id: true,
             password_hash: true,
             created_at: true

--- a/src/api/versions/v1/routes/auth/index.ts
+++ b/src/api/versions/v1/routes/auth/index.ts
@@ -10,34 +10,75 @@ import { APIResponseSpec, APIRouteSpec } from "../../../../utils/specHelpers";
 import { router as resetPasswordRouter } from "./reset-password";
 import { DOCS_TAGS } from "../../docs";
 
+// Dummy bcrypt hash for timing-normalized login failures — prevents username enumeration
+// Generated once at module load so it's a valid, cost-equivalent hash
+const DUMMY_PASSWORD_HASH = await Bun.password.hash("dummy-timing-constant");
+
 // Simple in-memory rate limiter for login to reduce brute-force risk
 const LOGIN_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
 const LOGIN_MAX_ATTEMPTS = 5;
+const LOGIN_MAX_GLOBAL_ATTEMPTS = 15; // Per-username limit across all IPs
 const loginAttempts = new Map<string, { count: number; resetAt: number }>();
+const globalLoginAttempts = new Map<string, { count: number; resetAt: number }>();
+
+// Periodic cleanup to prevent unbounded memory growth — runs every 5 minutes
+const LOGIN_CLEANUP_INTERVAL = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of loginAttempts) {
+        if (entry.resetAt <= now) loginAttempts.delete(key);
+    }
+    for (const [key, entry] of globalLoginAttempts) {
+        if (entry.resetAt <= now) globalLoginAttempts.delete(key);
+    }
+}, LOGIN_WINDOW_MS);
+// Allow the process to exit without waiting for this interval
+LOGIN_CLEANUP_INTERVAL.unref();
 
 function getClientId(c: Context) {
-    // Prefer forwarded header, fallback to remote IP if available
-    const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
     // @ts-ignore bun/hono provides a native request with connection info
     const remote = (c.req.raw as any)?.remoteAddr?.hostname;
-    return forwarded || remote || "unknown";
+    return remote || "unknown";
 }
 
-function isLoginRateLimited(clientId: string) {
+function getLoginAttemptKey(clientId: string, username: string) {
+    return `${clientId}:${username.toLowerCase()}`;
+}
+
+function getGlobalLoginAttemptKey(username: string) {
+    return username.toLowerCase();
+}
+
+/**
+ * Register a failed attempt, incrementing the counter atomically.
+ * Returns the new count after increment — no await between read and write.
+ */
+function registerFailedLoginAttempt(loginAttemptKey: string, globalKey: string): { perIpCount: number; globalCount: number } {
     const now = Date.now();
-    const entry = loginAttempts.get(clientId);
 
+    // Per-IP-per-username counter
+    let entry = loginAttempts.get(loginAttemptKey);
     if (!entry || entry.resetAt <= now) {
-        loginAttempts.set(clientId, { count: 1, resetAt: now + LOGIN_WINDOW_MS });
-        return { limited: false };
+        entry = { count: 1, resetAt: now + LOGIN_WINDOW_MS };
+        loginAttempts.set(loginAttemptKey, entry);
+    } else {
+        entry.count += 1;
     }
 
-    if (entry.count >= LOGIN_MAX_ATTEMPTS) {
-        return { limited: true, retryAfterMs: entry.resetAt - now };
+    // Global per-username counter
+    let globalEntry = globalLoginAttempts.get(globalKey);
+    if (!globalEntry || globalEntry.resetAt <= now) {
+        globalEntry = { count: 1, resetAt: now + LOGIN_WINDOW_MS };
+        globalLoginAttempts.set(globalKey, globalEntry);
+    } else {
+        globalEntry.count += 1;
     }
 
-    entry.count += 1;
-    return { limited: false };
+    return { perIpCount: entry.count, globalCount: globalEntry.count };
+}
+
+function clearFailedLoginAttempts(loginAttemptKey: string, globalKey: string) {
+    loginAttempts.delete(loginAttemptKey);
+    globalLoginAttempts.delete(globalKey);
 }
 
 export const router = new Hono().basePath('/auth');
@@ -60,18 +101,33 @@ router.post('/login',
     zValidator("json", AuthModel.Login.Body),
     
     async (c) => {
+
+        //@ts-ignore
+        const authContext = c.get("authContext") as AuthHandler.UnauthenticatedAuthContext;
+        if (authContext.type !== 'unauthenticated') {
+            return APIResponse.forbidden(c, "You are already authenticated");
+        }
+
+
+        const { username, password } = c.req.valid("json");
+
         const clientId = getClientId(c);
-        const rate = isLoginRateLimited(clientId);
-        if (rate.limited) {
-            const retrySeconds = Math.max(1, Math.ceil((rate.retryAfterMs ?? LOGIN_WINDOW_MS) / 1000));
+        const loginAttemptKey = getLoginAttemptKey(clientId, username);
+        const globalKey = getGlobalLoginAttemptKey(username);
+
+        // Increment counters FIRST, then check limits — eliminates TOCTOU race
+        const { perIpCount, globalCount } = registerFailedLoginAttempt(loginAttemptKey, globalKey);
+
+        if (perIpCount > LOGIN_MAX_ATTEMPTS || globalCount > LOGIN_MAX_GLOBAL_ATTEMPTS) {
+            const retrySeconds = Math.max(1, Math.ceil(LOGIN_WINDOW_MS / 1000));
             c.header("Retry-After", retrySeconds.toString());
             return c.json({ success: false, code: 429, message: `Too many login attempts. Try again in ${retrySeconds}s` }, 429);
         }
 
-        const { username, password } = c.req.valid("json");
-
-        const user = DB.instance().select().from(DB.Schema.users).where(eq(DB.Schema.users.username, username)).get();
+        const user = DB.instance().select().from(DB.Tables.users).where(eq(DB.Tables.users.username, username)).get();
         if (!user) {
+            // Timing-normalized: always run a bcrypt call to prevent username enumeration
+            await Bun.password.verify("dummy-timing-constant", DUMMY_PASSWORD_HASH);
             return APIResponse.unauthorized(c, "Invalid username or password");
         }
 
@@ -79,6 +135,9 @@ router.post('/login',
         if (!passwordMatch) {
             return APIResponse.unauthorized(c, "Invalid username or password");
         }
+
+        // Successful login — clear all counters for this user
+        clearFailedLoginAttempts(loginAttemptKey, globalKey);
 
         const session = await SessionHandler.createSession(user.id);
 

--- a/src/api/versions/v1/routes/auth/model.ts
+++ b/src/api/versions/v1/routes/auth/model.ts
@@ -10,7 +10,7 @@ export namespace AuthModel.Login {
     });
     export type Body = z.infer<typeof Body>;
 
-    export const Response = createSelectSchema(DB.Schema.sessions).omit({
+    export const Response = createSelectSchema(DB.Tables.sessions).omit({
         id: true,
         hashed_token: true
     }).extend({
@@ -21,7 +21,7 @@ export namespace AuthModel.Login {
 
 export namespace AuthModel.Session {
 
-    export const Response = createSelectSchema(DB.Schema.sessions).omit({
+    export const Response = createSelectSchema(DB.Tables.sessions).omit({
         id: true,
         hashed_token: true
     });

--- a/src/api/versions/v1/routes/auth/reset-password/index.ts
+++ b/src/api/versions/v1/routes/auth/reset-password/index.ts
@@ -7,7 +7,48 @@ import { APIResponse } from "../../../../../utils/api-res";
 import { AuthHandler, SessionHandler } from "../../../../../utils/authHandler";
 import { APIResponseSpec, APIRouteSpec } from "../../../../../utils/specHelpers";
 import { DOCS_TAGS } from "../../../docs";
-import { randomBytes as crypto_randomBytes } from "crypto" 
+import { randomBytes as crypto_randomBytes, createHash as crypto_createHash } from "crypto"
+import { EmailService } from "../../../../../utils/email";
+
+
+// In-memory rate limiter for password reset requests
+const RESET_REQUEST_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const RESET_REQUEST_MAX_PER_EMAIL = 1;
+const RESET_CONSUME_MAX_PER_TOKEN = 3;
+const resetRequestAttempts = new Map<string, { count: number; resetAt: number }>();
+const resetConsumeAttempts = new Map<string, { count: number; resetAt: number }>();
+
+// Periodic cleanup to prevent memory leaks
+const RESET_CLEANUP_INTERVAL = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of resetRequestAttempts) {
+        if (entry.resetAt <= now) resetRequestAttempts.delete(key);
+    }
+    for (const [key, entry] of resetConsumeAttempts) {
+        if (entry.resetAt <= now) resetConsumeAttempts.delete(key);
+    }
+}, RESET_REQUEST_WINDOW_MS);
+RESET_CLEANUP_INTERVAL.unref();
+
+export function hashResetToken(resetToken: string) {
+    return crypto_createHash("sha256").update(resetToken).digest("hex");
+}
+
+function checkRateLimit(map: Map<string, { count: number; resetAt: number }>, key: string, maxAttempts: number, windowMs: number): boolean {
+    const now = Date.now();
+    let entry = map.get(key);
+    if (!entry || entry.resetAt <= now) {
+        entry = { count: 1, resetAt: now + windowMs };
+        map.set(key, entry);
+        return true; // allowed
+    }
+    entry.count += 1;
+    if (entry.count > maxAttempts) {
+        return false; // blocked
+    }
+    return true;
+}
+
 
 export const router = new Hono().basePath('/reset-password');
 
@@ -20,7 +61,7 @@ router.post('/',
 
         responses: APIResponseSpec.describeWithWrongInputs(
             APIResponseSpec.badRequest("Invalid reset token"),
-            APIResponseSpec.serverError("User for reset token not found"),
+            APIResponseSpec.unauthorized("You are already authenticated"),
             APIResponseSpec.successNoData("Password has been reset successfully")
         ),
     }),
@@ -28,10 +69,22 @@ router.post('/',
     zValidator("json", ResetPasswordModel.Reset.Body),
 
     async (c) => {
-        const resetData = c.req.valid("json");
+        //@ts-ignore
+        const authContext = c.get("authContext") as AuthHandler.UnauthenticatedAuthContext;
+        if (authContext.type !== 'unauthenticated') {
+            return APIResponse.unauthorized(c, "You are already authenticated");
+        }
 
-        const checkToken = DB.instance().select().from(DB.Schema.passwordResets).where(
-            eq(DB.Schema.passwordResets.token, resetData.reset_token)
+        const resetData = c.req.valid("json");
+        const hashedResetToken = hashResetToken(resetData.reset_token);
+
+        // Rate limit: max 3 attempts per token
+        if (!checkRateLimit(resetConsumeAttempts, hashedResetToken, RESET_CONSUME_MAX_PER_TOKEN, RESET_REQUEST_WINDOW_MS)) {
+            return APIResponse.badRequest(c, "Invalid reset token");
+        }
+
+        let checkToken = DB.instance().select().from(DB.Tables.passwordResets).where(
+            eq(DB.Tables.passwordResets.token, hashedResetToken)
         ).get();
 
         if (!checkToken) {
@@ -42,27 +95,26 @@ router.post('/',
             return APIResponse.badRequest(c, "Invalid reset token");
         }
 
-        const user = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.id, checkToken.user_id)
+        const user = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.id, checkToken.user_id)
         ).get();
 
         if (!user) {
-            return APIResponse.serverError(c, "User for reset token not found");
+            throw new Error("User for reset token not found");
         }
 
         const newPasswordHash = await Bun.password.hash(resetData.new_password);
 
-        DB.instance().update(DB.Schema.users).set({
+        await DB.instance().update(DB.Tables.users).set({
             password_hash: newPasswordHash
         }).where(
-            eq(DB.Schema.users.id, user.id)
+            eq(DB.Tables.users.id, user.id)
         ).run();
 
-        await SessionHandler.inValidateAllSessionsForUser(user.id);
+        await AuthHandler.invalidateAllAuthContextsForUser(user.id);
 
-        // Delete used reset token
-        DB.instance().delete(DB.Schema.passwordResets).where(
-            eq(DB.Schema.passwordResets.token, resetData.reset_token)
+        await DB.instance().delete(DB.Tables.passwordResets).where(
+            eq(DB.Tables.passwordResets.user_id, user.id)
         ).run();
 
         return APIResponse.successNoData(c, "Password has been reset successfully");
@@ -84,30 +136,43 @@ router.post('/request',
     zValidator("json", ResetPasswordModel.RequestReset.Body),
 
     async (c) => {
+
+        //@ts-ignore
+        const authContext = c.get("authContext") as AuthHandler.UnauthenticatedAuthContext;
+        if (authContext.type !== 'unauthenticated') {
+            return APIResponse.unauthorized(c, "You are already authenticated");
+        }
+
         const requestData = c.req.valid("json");
 
-        const user = DB.instance().select().from(DB.Schema.users).where(
-            eq(DB.Schema.users.email, requestData.email)
+        // Rate limit: max 1 reset request per email per 15 minutes
+        if (!checkRateLimit(resetRequestAttempts, requestData.email.toLowerCase(), RESET_REQUEST_MAX_PER_EMAIL, RESET_REQUEST_WINDOW_MS)) {
+            return APIResponse.successNoData(c, "If the username exists, a password reset has been requested");
+        }
+
+        const user = DB.instance().select().from(DB.Tables.users).where(
+            eq(DB.Tables.users.email, requestData.email)
         ).get();
 
         if (user) {
             const resetToken = crypto_randomBytes(64).toString('hex');
 
             // Delete any existing reset tokens for this user
-            DB.instance().delete(DB.Schema.passwordResets).where(
-                eq(DB.Schema.passwordResets.user_id, user.id)
+            await DB.instance().delete(DB.Tables.passwordResets).where(
+                eq(DB.Tables.passwordResets.user_id, user.id)
             ).run();
 
-            // Create new reset token
-            DB.instance().insert(DB.Schema.passwordResets).values({
+            // Create new reset token — 1 hour expiry (OWASP recommendation: 15-60 min)
+            await DB.instance().insert(DB.Tables.passwordResets).values({
                 user_id: user.id,
-                token: resetToken,
-                // 7 Days
-                expires_at: Date.now() + 7 * 24 * 60 * 60 * 1000
+                token: hashResetToken(resetToken),
+                expires_at: Date.now() + 60 * 60 * 1000 // 1 hour
             }).run();
 
-            // send email with reset token
-            // Note: Email sending is not implemented yet
+            // send email with reset token (fire-and-forget — errors are logged server-side)
+            if (EmailService.isEnabled()) {
+                EmailService.sendPasswordResetEmail(user.email, resetToken);
+            }
         }
 
         return APIResponse.successNoData(c, "If the username exists, a password reset has been requested");

--- a/src/api/versions/v1/routes/mail-accounts/identities/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/identities/index.ts
@@ -28,8 +28,8 @@ router.get('/',
         // @ts-ignore
         const mailAccount = c.get("mailAccount") as MailAccountsModel.BASE;
 
-        const mailIdentities = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.mail_account_id, mailAccount.id),
+        const mailIdentities = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.mail_account_id, mailAccount.id),
         ).all();
         
         return APIResponse.success(c, "Mail identities retrieved successfully", mailIdentities satisfies MailIdentitiesModel.GetAll.Response);
@@ -58,17 +58,17 @@ router.post('/',
 
         if (body.is_default) {
             // If setting this mail identity as default, unset all other identities for this mail account
-            await DB.instance().update(DB.Schema.mailIdentities).set({
+            await DB.instance().update(DB.Tables.mailIdentities).set({
                 is_default: false
             }).where(
                 and(
-                    eq(DB.Schema.mailIdentities.mail_account_id, mailAccount.id),
-                    eq(DB.Schema.mailIdentities.is_default, true),
+                    eq(DB.Tables.mailIdentities.mail_account_id, mailAccount.id),
+                    eq(DB.Tables.mailIdentities.is_default, true),
                 )
             );
         }
 
-        const result = await DB.instance().insert(DB.Schema.mailIdentities).values({
+        const result = await DB.instance().insert(DB.Tables.mailIdentities).values({
             ...body,
             mail_account_id: mailAccount.id,
         }).returning().get();
@@ -88,10 +88,10 @@ router.use('/:mailIdentityID/*',
         // @ts-ignore
         const mailAccount = c.get("mailAccount") as MailAccountsModel.BASE;
 
-        const mailIdentity = DB.instance().select().from(DB.Schema.mailIdentities).where(
+        const mailIdentity = DB.instance().select().from(DB.Tables.mailIdentities).where(
             and(
-                eq(DB.Schema.mailIdentities.id, mailIdentityID),
-                eq(DB.Schema.mailIdentities.mail_account_id, mailAccount.id),
+                eq(DB.Tables.mailIdentities.id, mailIdentityID),
+                eq(DB.Tables.mailIdentities.mail_account_id, mailAccount.id),
             )
         ).get();
 
@@ -150,21 +150,21 @@ router.put('/:mailIdentityID',
 
         if (body.is_default && !mailIdentity.is_default) {
             // If setting this mail identity as default, unset all other identities for this mail account
-            await DB.instance().update(DB.Schema.mailIdentities).set({
+            await DB.instance().update(DB.Tables.mailIdentities).set({
                 is_default: false
             }).where(
                 and(
-                    eq(DB.Schema.mailIdentities.mail_account_id, mailIdentity.mail_account_id),
-                    eq(DB.Schema.mailIdentities.is_default, true),
-                    ne(DB.Schema.mailIdentities.id, mailIdentity.id)
+                    eq(DB.Tables.mailIdentities.mail_account_id, mailIdentity.mail_account_id),
+                    eq(DB.Tables.mailIdentities.is_default, true),
+                    ne(DB.Tables.mailIdentities.id, mailIdentity.id)
                 )
             );
         }
 
-        await DB.instance().update(DB.Schema.mailIdentities).set({
+        await DB.instance().update(DB.Tables.mailIdentities).set({
             ...body
         }).where(
-            eq(DB.Schema.mailIdentities.id, mailIdentity.id)
+            eq(DB.Tables.mailIdentities.id, mailIdentity.id)
         );
 
         return APIResponse.successNoData(c, "Mail identity updated successfully");
@@ -188,8 +188,8 @@ router.delete('/:mailIdentityID',
         // @ts-ignore
         const mailIdentity = c.get("mailIdentity") as MailIdentitiesModel.BASE;
 
-        await DB.instance().delete(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.id, mailIdentity.id)
+        await DB.instance().delete(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.id, mailIdentity.id)
         );
 
         return APIResponse.successNoData(c, "Mail identity deleted successfully");

--- a/src/api/versions/v1/routes/mail-accounts/identities/model.ts
+++ b/src/api/versions/v1/routes/mail-accounts/identities/model.ts
@@ -4,7 +4,7 @@ import { createInsertSchema, createUpdateSchema, createSelectSchema } from "driz
 
 export namespace MailIdentitiesModel {
 
-    export const BASE = createSelectSchema(DB.Schema.mailIdentities, {
+    export const BASE = createSelectSchema(DB.Tables.mailIdentities, {
         id: z.int().positive(),
         created_at: z.int().positive(),
 

--- a/src/api/versions/v1/routes/mail-accounts/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/index.ts
@@ -36,8 +36,8 @@ router.get('/',
 
         const authContext = AuthHandler.AuthContext.get(c);
 
-        const mailAccountsRaw = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.owner_user_id, authContext.user_id)
+        const mailAccountsRaw = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.owner_user_id, authContext.user_id)
         ).all();
 
         const mailAccounts = await Promise.all(mailAccountsRaw.map(async (account) => {
@@ -125,12 +125,12 @@ router.post('/',
 
         if (body.is_default) {
             // If setting this mail account as default, unset all other mail accounts for this user
-            await DB.instance().update(DB.Schema.mailAccounts).set({
+            await DB.instance().update(DB.Tables.mailAccounts).set({
                 is_default: false
             }).where(
                 and(
-                    eq(DB.Schema.mailAccounts.owner_user_id, authContext.user_id),
-                    eq(DB.Schema.mailAccounts.is_default, true),
+                    eq(DB.Tables.mailAccounts.owner_user_id, authContext.user_id),
+                    eq(DB.Tables.mailAccounts.is_default, true),
                 )
             );
         }
@@ -155,7 +155,7 @@ router.post('/',
             return APIResponse.serverError(c, "Failed to encrypt mail account data");
         }
 
-        const result = await DB.instance().insert(DB.Schema.mailAccounts).values({
+        const result = await DB.instance().insert(DB.Tables.mailAccounts).values({
             display_name: body.display_name,
             is_default: body.is_default,
             smtp_encrypted_connection_data: encryptedSMTPData,
@@ -178,10 +178,10 @@ router.use("/:mailAccountID/*",
         // @ts-ignore
         const { mailAccountID } = c.req.valid("param") as MailAccountsModel.MailAccountIDParams;
 
-        let encryptedMailAccount = DB.instance().select().from(DB.Schema.mailAccounts).where(
+        let encryptedMailAccount = DB.instance().select().from(DB.Tables.mailAccounts).where(
             and(
-                eq(DB.Schema.mailAccounts.id, mailAccountID),
-                eq(DB.Schema.mailAccounts.owner_user_id, authContext.user_id)
+                eq(DB.Tables.mailAccounts.id, mailAccountID),
+                eq(DB.Tables.mailAccounts.owner_user_id, authContext.user_id)
             )
         ).get();
 
@@ -313,19 +313,19 @@ router.put('/:mailAccountID',
 
         if (body.is_default && !mailAccount.is_default) {
             // If setting this mail account as default, unset all other mail accounts for this user
-            await DB.instance().update(DB.Schema.mailAccounts).set({
+            await DB.instance().update(DB.Tables.mailAccounts).set({
                 is_default: false
             }).where(
                 and(
-                    eq(DB.Schema.mailAccounts.owner_user_id, mailAccount.owner_user_id),
-                    eq(DB.Schema.mailAccounts.is_default, true),
-                    ne(DB.Schema.mailAccounts.id, mailAccount.id)
+                    eq(DB.Tables.mailAccounts.owner_user_id, mailAccount.owner_user_id),
+                    eq(DB.Tables.mailAccounts.is_default, true),
+                    ne(DB.Tables.mailAccounts.id, mailAccount.id)
                 )
             );
         }
 
-        await DB.instance().update(DB.Schema.mailAccounts).set(body).where(
-            eq(DB.Schema.mailAccounts.id, mailAccount.id)
+        await DB.instance().update(DB.Tables.mailAccounts).set(body).where(
+            eq(DB.Tables.mailAccounts.id, mailAccount.id)
         )
 
         return APIResponse.successNoData(c, "Mail account updated successfully");
@@ -377,11 +377,11 @@ router.put('/:mailAccountID/credentials',
             return APIResponse.serverError(c, "Failed to encrypt mail account data");
         }
 
-        await DB.instance().update(DB.Schema.mailAccounts).set({
+        await DB.instance().update(DB.Tables.mailAccounts).set({
             smtp_encrypted_connection_data: encryptedSMTPData,
             imap_encrypted_connection_data: encryptedIMAPData
         }).where(
-            eq(DB.Schema.mailAccounts.id, mailAccount.id)
+            eq(DB.Tables.mailAccounts.id, mailAccount.id)
         )
 
         return APIResponse.successNoData(c, "Mail account credentials updated successfully");
@@ -409,12 +409,12 @@ router.delete('/:mailAccountID',
         await MailClientsCache.deleteClient(mailAccount.id);
 
         // Delete all mail identities linked to this mail account
-        await DB.instance().delete(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.mail_account_id, mailAccount.id)
+        await DB.instance().delete(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.mail_account_id, mailAccount.id)
         );
 
-        await DB.instance().delete(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccount.id)
+        await DB.instance().delete(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccount.id)
         );
 
         return APIResponse.successNoData(c, "Mail account deleted successfully");

--- a/src/api/versions/v1/routes/mail-accounts/model.ts
+++ b/src/api/versions/v1/routes/mail-accounts/model.ts
@@ -7,7 +7,7 @@ import { MailboxesModel } from "./mailboxes/model";
 
 export namespace MailAccountsModel {
 
-    export const BASE = createSelectSchema(DB.Schema.mailAccounts).extend({
+    export const BASE = createSelectSchema(DB.Tables.mailAccounts).extend({
         id: z.int().positive(),
         created_at: z.int().positive(),
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,6 @@
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as TableSchema from './schema/sqlite';
-import { randomBytes as crypto_randomBytes } from 'crypto';
+import { randomBytes as crypto_randomBytes, createHash as crypto_createHash } from 'crypto';
 import { type DrizzleDB } from './utils';
 import { Logger } from '../utils/logger';
 import { ConfigHandler } from '../utils/config';
@@ -33,12 +33,12 @@ export class DB {
     }
 
     static async createInitialAdminUserIfNeeded(configBaseDir: string) {
-        const usersTableEmpty = (await this.db.select().from(DB.Schema.users).limit(1)).length === 0;
+        const usersTableEmpty = (await this.db.select().from(DB.Tables.users).limit(1)).length === 0;
         if (!usersTableEmpty) return;
 
         const username = "admin";
 
-        const admin_user_id = await this.db.insert(DB.Schema.users).values({
+        const admin_user_id = await this.db.insert(DB.Tables.users).values({
             username,
             email: "admin@delivr.local",
             password_hash: await Bun.password.hash(crypto_randomBytes(32).toString('hex')),
@@ -47,8 +47,8 @@ export class DB {
         }).returning().get().id;
 
         const passwordResetToken = crypto_randomBytes(64).toString('hex');
-        await this.db.insert(DB.Schema.passwordResets).values({
-            token: passwordResetToken,
+        await this.db.insert(DB.Tables.passwordResets).values({
+            token: crypto_createHash('sha256').update(passwordResetToken).digest('hex'),
             user_id: admin_user_id,
             expires_at: Date.now() + 7 * 24 * 60 * 60 * 1000 // 7 Days
         });
@@ -91,7 +91,7 @@ export class DB {
 }
 
 
-export namespace DB.Schema {
+export namespace DB.Tables {
     export const users = TableSchema.users;
     export const sessions = TableSchema.sessions;
     export const passwordResets = TableSchema.passwordResets;
@@ -105,14 +105,14 @@ export namespace DB.Schema {
 }
 
 export namespace DB.Models {
-    export type User = typeof DB.Schema.users.$inferSelect;
-    export type Session = typeof DB.Schema.sessions.$inferSelect;
-    export type PasswordReset = typeof DB.Schema.passwordResets.$inferSelect;
-    export type ApiKey = typeof DB.Schema.apiKeys.$inferSelect;
+    export type User = typeof DB.Tables.users.$inferSelect;
+    export type Session = typeof DB.Tables.sessions.$inferSelect;
+    export type PasswordReset = typeof DB.Tables.passwordResets.$inferSelect;
+    export type ApiKey = typeof DB.Tables.apiKeys.$inferSelect;
 
-    export type MailAccount = typeof DB.Schema.mailAccounts.$inferSelect;
-    export type MailIdentity = typeof DB.Schema.mailIdentities.$inferSelect;
+    export type MailAccount = typeof DB.Tables.mailAccounts.$inferSelect;
+    export type MailIdentity = typeof DB.Tables.mailIdentities.$inferSelect;
 
-    export type Metadata = typeof DB.Schema.metadata.$inferSelect;
-    export type UserPreference = typeof DB.Schema.userPreferences.$inferSelect;
+    export type Metadata = typeof DB.Tables.metadata.$inferSelect;
+    export type UserPreference = typeof DB.Tables.userPreferences.$inferSelect;
 }

--- a/src/db/schema/mysql.ts
+++ b/src/db/schema/mysql.ts
@@ -8,7 +8,7 @@
 // import { InetModels } from '../../api/utils/shared-models/inetModels';
 
 // /**
-//  * @deprecated Use DB.Schema.users instead
+//  * @deprecated Use DB.Tables.users instead
 //  */
 // export const users = mysqlTable('users', {
 //     id: integer().primaryKey({ autoIncrement: true }),
@@ -23,7 +23,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.passwordResets instead
+//  * @deprecated Use DB.Tables.passwordResets instead
 //  */
 // export const passwordResets = mysqlTable('password_resets', {
 //     token: text().primaryKey(),
@@ -33,7 +33,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.sessions instead
+//  * @deprecated Use DB.Tables.sessions instead
 //  */
 // export const sessions = mysqlTable('sessions', {
 //     id: text().primaryKey(),
@@ -47,7 +47,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.apiKeys instead
+//  * @deprecated Use DB.Tables.apiKeys instead
 //  */
 // export const apiKeys = mysqlTable('api_keys', {
 //     id: text().primaryKey(),
@@ -63,7 +63,7 @@
 
 
 // /**
-//  * @deprecated Use DB.Schema.mailAccounts instead
+//  * @deprecated Use DB.Tables.mailAccounts instead
 //  */
 // export const mailAccounts = mysqlTable('mail_accounts', {
 //     id: integer().primaryKey({ autoIncrement: true }),
@@ -93,7 +93,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.mailIdentities instead
+//  * @deprecated Use DB.Tables.mailIdentities instead
 //  */
 // export const mailIdentities = mysqlTable('mail_identities', {
 //     id: integer().primaryKey({ autoIncrement: true }),
@@ -108,7 +108,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.metadata instead
+//  * @deprecated Use DB.Tables.metadata instead
 //  */
 // export const metadata = mysqlTable('metadata', {
 //     key: text().primaryKey(),
@@ -116,7 +116,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.userPreferences instead
+//  * @deprecated Use DB.Tables.userPreferences instead
 //  */
 // export const userPreferences = mysqlTable('user_preferences', {
 //     id: integer().primaryKey({ autoIncrement: true }),

--- a/src/db/schema/postgresql.ts
+++ b/src/db/schema/postgresql.ts
@@ -11,7 +11,7 @@
 // import { InetModels } from '../../api/utils/shared-models/inetModels';
 
 // /**
-//  * @deprecated Use DB.Schema.users instead
+//  * @deprecated Use DB.Tables.users instead
 //  */
 // export const users = pgTable('users', {
 //     id: serial().primaryKey(),
@@ -26,7 +26,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.passwordResets instead
+//  * @deprecated Use DB.Tables.passwordResets instead
 //  */
 // export const passwordResets = pgTable('password_resets', {
 //     token: text().primaryKey(),
@@ -36,7 +36,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.sessions instead
+//  * @deprecated Use DB.Tables.sessions instead
 //  */
 // export const sessions = pgTable('sessions', {
 //     id: text().primaryKey(),
@@ -50,7 +50,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.apiKeys instead
+//  * @deprecated Use DB.Tables.apiKeys instead
 //  */
 // export const apiKeys = pgTable('api_keys', {
 //     id: text().primaryKey(),
@@ -66,7 +66,7 @@
 
 
 // /**
-//  * @deprecated Use DB.Schema.mailAccounts instead
+//  * @deprecated Use DB.Tables.mailAccounts instead
 //  */
 // export const mailAccounts = pgTable('mail_accounts', {
 //     id: integer().primaryKey({ autoIncrement: true }),
@@ -96,7 +96,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.mailIdentities instead
+//  * @deprecated Use DB.Tables.mailIdentities instead
 //  */
 // export const mailIdentities = pgTable('mail_identities', {
 //     id: integer().primaryKey({ autoIncrement: true }),
@@ -111,7 +111,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.metadata instead
+//  * @deprecated Use DB.Tables.metadata instead
 //  */
 // export const metadata = pgTable('metadata', {
 //     key: text().primaryKey(),
@@ -119,7 +119,7 @@
 // });
 
 // /**
-//  * @deprecated Use DB.Schema.userPreferences instead
+//  * @deprecated Use DB.Tables.userPreferences instead
 //  */
 // export const userPreferences = pgTable('user_preferences', {
 //     id: serial().primaryKey(),

--- a/src/db/schema/sqlite.ts
+++ b/src/db/schema/sqlite.ts
@@ -9,7 +9,7 @@ import { UserAccountSettings } from '../../api/utils/shared-models/accountData';
 import { InetModels } from '../../api/utils/shared-models/inetModels';
 
 /**
- * @deprecated Use DB.Schema.users instead
+ * @deprecated Use DB.Tables.users instead
  */
 export const users = sqliteTable('users', {
     id: integer().primaryKey({ autoIncrement: true }),
@@ -24,7 +24,7 @@ export const users = sqliteTable('users', {
 });
 
 /**
- * @deprecated Use DB.Schema.passwordResets instead
+ * @deprecated Use DB.Tables.passwordResets instead
  */
 export const passwordResets = sqliteTable('password_resets', {
     token: text().primaryKey(),
@@ -34,7 +34,7 @@ export const passwordResets = sqliteTable('password_resets', {
 });
 
 /**
- * @deprecated Use DB.Schema.sessions instead
+ * @deprecated Use DB.Tables.sessions instead
  */
 export const sessions = sqliteTable('sessions', {
     id: text().primaryKey(),
@@ -48,7 +48,7 @@ export const sessions = sqliteTable('sessions', {
 });
 
 /**
- * @deprecated Use DB.Schema.apiKeys instead
+ * @deprecated Use DB.Tables.apiKeys instead
  */
 export const apiKeys = sqliteTable('api_keys', {
     id: text().primaryKey(),
@@ -64,7 +64,7 @@ export const apiKeys = sqliteTable('api_keys', {
 
 
 /**
- * @deprecated Use DB.Schema.mailAccounts instead
+ * @deprecated Use DB.Tables.mailAccounts instead
  */
 export const mailAccounts = sqliteTable('mail_accounts', {
     id: integer().primaryKey({ autoIncrement: true }),
@@ -97,7 +97,7 @@ export const mailAccounts = sqliteTable('mail_accounts', {
 });
 
 /**
- * @deprecated Use DB.Schema.mailIdentities instead
+ * @deprecated Use DB.Tables.mailIdentities instead
  */
 export const mailIdentities = sqliteTable('mail_identities', {
     id: integer().primaryKey({ autoIncrement: true }),
@@ -112,7 +112,7 @@ export const mailIdentities = sqliteTable('mail_identities', {
 });
 
 /**
- * @deprecated Use DB.Schema.metadata instead
+ * @deprecated Use DB.Tables.metadata instead
  */
 export const metadata = sqliteTable('metadata', {
     key: text().primaryKey(),
@@ -120,7 +120,7 @@ export const metadata = sqliteTable('metadata', {
 });
 
 /**
- * @deprecated Use DB.Schema.userPreferences instead
+ * @deprecated Use DB.Tables.userPreferences instead
  */
 export const userPreferences = sqliteTable('user_preferences', {
     id: integer().primaryKey({ autoIncrement: true }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Utils } from "./utils";
 import { MailClientsCache } from "./utils/mails/mail-clients-cache";
 import { CronJobHandler } from "./utils/cron";
 import { MailAccountEncryption } from "./utils/crypto/mailCrypt";
+import { EmailService } from "./api/utils/email";
 
 export class Main {
 
@@ -32,6 +33,7 @@ export class Main {
 
         await Utils.ensureDirectoryExists(config.DLA_LOG_DIR ?? "./data/logs");
 
+        EmailService.init();
         
         await CronJobHandler.init();
         await CronJobHandler.startAll();
@@ -52,6 +54,7 @@ export class Main {
 
             await CronJobHandler.stopAll();
             await API.stop();
+            EmailService.reset();
             await MailClientsCache.clearAllClients();
             await DB.close();
             

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -118,7 +118,14 @@ export class ConfigHandler {
         .add("DLA_CONFIG_BASE_DIR", false)
 
         .add("DLA_DB_CONNECTION_URL", false)
-        .add("DLA_DB_AUTO_MIGRATE", false, [true, false]);
+        .add("DLA_DB_AUTO_MIGRATE", false, [true, false])
+
+        .add("DLA_SMTP_HOST", false)
+        .add("DLA_SMTP_PORT", false)
+        .add("DLA_SMTP_USERNAME", false)
+        .add("DLA_SMTP_PASSWORD", false)
+        .add("DLA_SMTP_FROM", false)
+        .add("DLA_SMTP_SECURE", false, [true, false]);
 
 
     private static config: ParsedConfig | null = null;

--- a/tests/api.routes.test.ts
+++ b/tests/api.routes.test.ts
@@ -16,12 +16,13 @@ import { MailAccountEncryption } from "../src/utils/crypto/mailCrypt";
 import { MailsModel } from "../src/api/versions/v1/routes/mail-accounts/mailboxes/mails/model";
 import { SearchModel } from "../src/api/versions/v1/routes/mail-accounts/search/model";
 import { MailBulkActionsModel } from "../src/api/versions/v1/routes/mail-accounts/mailboxes/mail-bulk-actions/model";
+import { hashResetToken } from "../src/api/versions/v1/routes/auth/reset-password";
 
 type SeededUser = Omit<DB.Models.User, "password_hash"> & { password: string };
 type SeededSession = Awaited<ReturnType<typeof SessionHandler.createSession>>;
 
 async function seedUser(role: DB.Models.User["role"], overrides: Partial<DB.Models.User> = {}, password = "TestP@ssw0rd") {
-    const user = DB.instance().insert(DB.Schema.users).values({
+    const user = DB.instance().insert(DB.Tables.users).values({
         username: overrides.username ?? `user_${randomUUID().slice(0, 8)}`,
         display_name: overrides.display_name ?? "Test User",
         email: overrides.email ?? `${randomUUID()}@example.com`,
@@ -60,7 +61,7 @@ async function seedMailAccount(ownerUserId: number) {
     }
 
     // Seed a mail account
-    const mailAccount = await DB.instance().insert(DB.Schema.mailAccounts).values({
+    const mailAccount = await DB.instance().insert(DB.Tables.mailAccounts).values({
         owner_user_id: ownerUserId,
         display_name: "Test Mail Account",
         smtp_encrypted_connection_data: encryptedSMTPData,
@@ -154,6 +155,102 @@ describe("Auth routes and access checks", async () => {
     });
 });
 
+describe("Auth reset-password routes", async () => {
+
+    let resetUser: SeededUser;
+    let resetSessionToken: string;
+
+    beforeAll(async () => {
+        resetUser = await seedUser("user");
+        resetSessionToken = await seedSession(resetUser.id).then(s => s.token);
+    });
+
+    test("POST /v1/auth/reset-password/request returns success for existing and unknown emails", async () => {
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: resetUser.email }
+        }, 200);
+
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: `nope-${randomUUID()}@example.com` }
+        }, 200);
+    });
+
+    test("POST /v1/auth/reset-password/request denies authenticated users", async () => {
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            authToken: resetSessionToken,
+            body: { email: resetUser.email }
+        }, 401);
+    });
+
+    test("POST /v1/auth/reset-password with invalid token fails", async () => {
+        await makeAPIRequest("/v1/auth/reset-password", {
+            method: "POST",
+            body: {
+                reset_token: "invalid-token",
+                new_password: "ResetP@ssw0rd1"
+            }
+        }, 400);
+    });
+
+    test("POST /v1/auth/reset-password updates credentials for a valid reset token", async () => {
+        const validResetToken = `reset_${randomUUID().replace(/-/g, "")}`;
+        const nextPassword = "ResetP@ssw0rd1";
+        const wrongLoginIP = `203.0.113.${Math.floor(Math.random() * 200) + 1}`;
+        const correctLoginIP = `203.0.114.${Math.floor(Math.random() * 200) + 1}`;
+
+        await DB.instance().insert(DB.Tables.passwordResets).values({
+            token: hashResetToken(validResetToken),
+            user_id: resetUser.id,
+            expires_at: Date.now() + 10 * 60 * 1000
+        }).run();
+
+        await makeAPIRequest("/v1/auth/reset-password", {
+            method: "POST",
+            body: {
+                reset_token: validResetToken,
+                new_password: nextPassword
+            }
+        }, 200);
+
+        await makeAPIRequest("/v1/auth/session", {
+            authToken: resetSessionToken
+        }, 401);
+
+        await makeAPIRequest("/v1/auth/login", {
+            method: "POST",
+            body: {
+                username: resetUser.username,
+                password: resetUser.password
+            },
+            additionalOptions: {
+                headers: {
+                    "x-forwarded-for": wrongLoginIP
+                }
+            }
+        }, 401);
+
+        const login = await makeAPIRequest("/v1/auth/login", {
+            method: "POST",
+            body: {
+                username: resetUser.username,
+                password: nextPassword
+            },
+            additionalOptions: {
+                headers: {
+                    "x-forwarded-for": correctLoginIP
+                }
+            },
+            expectedBodySchema: AuthModel.Login.Response
+        }, 200);
+
+        expect(login.token.startsWith("dla_sess_")).toBe(true);
+        resetUser.password = nextPassword;
+    });
+});
+
 describe("Account routes", async () => {
 
     let session_token: string;
@@ -194,7 +291,7 @@ describe("Account routes", async () => {
         testUser.username = newUserData.username;
         testUser.email = newUserData.email;
 
-        const dbresult = DB.instance().select().from(DB.Schema.users).where(eq(DB.Schema.users.id, testUser.id)).get();
+        const dbresult = DB.instance().select().from(DB.Tables.users).where(eq(DB.Tables.users.id, testUser.id)).get();
 
         expect(dbresult?.display_name).toBe(newUserData.display_name);
         expect(dbresult?.username).toBe(newUserData.username);
@@ -209,7 +306,7 @@ describe("Account routes", async () => {
             body: { role: "admin" }
         }, 400);
         
-        const dbresult = DB.instance().select().from(DB.Schema.users).where(eq(DB.Schema.users.id, testUser.id)).get();
+        const dbresult = DB.instance().select().from(DB.Tables.users).where(eq(DB.Tables.users.id, testUser.id)).get();
         expect(dbresult?.role).toBe("user");
     });
 
@@ -262,8 +359,8 @@ describe("Account routes", async () => {
             authToken: session_token
         }, 400);
 
-        await DB.instance().delete(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        await DB.instance().delete(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).run();
     });
 
@@ -274,7 +371,7 @@ describe("Account routes", async () => {
             authToken: session_token
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.users).where(eq(DB.Schema.users.id, testUser.id)).get();
+        const dbresult = DB.instance().select().from(DB.Tables.users).where(eq(DB.Tables.users.id, testUser.id)).get();
         expect(dbresult).toBeUndefined();
 
         // recreate test user for further tests
@@ -295,12 +392,12 @@ describe("Account Preferences Routes", async () => {
     afterAll(async () => {
         SessionHandler.inValidateAllSessionsForUser(preferencesTestUser.id);
 
-        DB.instance().delete(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, preferencesTestUser.id)
+        DB.instance().delete(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, preferencesTestUser.id)
         ).run();
 
-        DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, preferencesTestUser.id)
+        DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, preferencesTestUser.id)
         ).run();
     });
 
@@ -315,8 +412,8 @@ describe("Account Preferences Routes", async () => {
         expect(data.domains).toEqual({});
 
         // No row should exist yet - this is a computed default, not a persisted one.
-        const dbresult = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, preferencesTestUser.id)
+        const dbresult = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, preferencesTestUser.id)
         ).all();
         expect(dbresult.length).toBe(0);
     });
@@ -344,8 +441,8 @@ describe("Account Preferences Routes", async () => {
         expect(data.addresses).toEqual({ "sender@example.com": "allow" });
         expect(data.domains).toEqual({});
 
-        const dbresult = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, preferencesTestUser.id)
+        const dbresult = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, preferencesTestUser.id)
         ).all();
         expect(dbresult.length).toBe(1);
         expect(dbresult[0]?.key).toBe("remote-content-policy");
@@ -371,8 +468,8 @@ describe("Account Preferences Routes", async () => {
         expect(data.addresses).toEqual({});
         expect(data.domains).toEqual({ "example.com": "block" });
 
-        const dbresult = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, preferencesTestUser.id)
+        const dbresult = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, preferencesTestUser.id)
         ).all();
         expect(dbresult.length).toBe(1);
     });
@@ -392,8 +489,8 @@ describe("Account Preferences Routes", async () => {
             })
         ]);
 
-        const dbresult = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, preferencesTestUser.id)
+        const dbresult = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, preferencesTestUser.id)
         ).all();
         expect(dbresult.length).toBe(1);
     });
@@ -433,7 +530,7 @@ describe("Account Preferences Routes", async () => {
         expect(data.domains).toEqual({});
 
         SessionHandler.inValidateAllSessionsForUser(otherUser.id);
-        DB.instance().delete(DB.Schema.users).where(eq(DB.Schema.users.id, otherUser.id)).run();
+        DB.instance().delete(DB.Tables.users).where(eq(DB.Tables.users.id, otherUser.id)).run();
     });
 
     test("DELETE /v1/account also removes stored preferences", async () => {
@@ -447,8 +544,8 @@ describe("Account Preferences Routes", async () => {
             body: { addresses: { "keep@example.com": "allow" }, domains: {} }
         });
 
-        const beforeDelete = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, deletableUser.id)
+        const beforeDelete = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, deletableUser.id)
         ).all();
         expect(beforeDelete.length).toBe(1);
 
@@ -457,8 +554,8 @@ describe("Account Preferences Routes", async () => {
             authToken: deletableSession
         });
 
-        const afterDelete = DB.instance().select().from(DB.Schema.userPreferences).where(
-            eq(DB.Schema.userPreferences.user_id, deletableUser.id)
+        const afterDelete = DB.instance().select().from(DB.Tables.userPreferences).where(
+            eq(DB.Tables.userPreferences.user_id, deletableUser.id)
         ).all();
         expect(afterDelete.length).toBe(0);
     });
@@ -506,8 +603,8 @@ describe("Mail Account Routes", async () => {
 
         expect(data.id).toBeGreaterThan(0);
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, data.id)
+        const dbresult = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, data.id)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -546,9 +643,9 @@ describe("Mail Account Routes", async () => {
 
         expect(Array.isArray(data)).toBe(true);
 
-        const dbresults = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.owner_user_id, mailAccountTestUser.id)
-        ).orderBy(desc(DB.Schema.mailAccounts.id)).all();
+        const dbresults = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.owner_user_id, mailAccountTestUser.id)
+        ).orderBy(desc(DB.Tables.mailAccounts.id)).all();
 
         expect(data.length).toBe(dbresults.length);
 
@@ -586,9 +683,9 @@ describe("Mail Account Routes", async () => {
 
         expect(Array.isArray(data)).toBe(true);
 
-        const dbresults = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.owner_user_id, mailAccountTestUser.id)
-        ).orderBy(desc(DB.Schema.mailAccounts.id)).all();
+        const dbresults = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.owner_user_id, mailAccountTestUser.id)
+        ).orderBy(desc(DB.Tables.mailAccounts.id)).all();
 
         expect(data.length).toBe(dbresults.length);
 
@@ -656,8 +753,8 @@ describe("Mail Account Routes", async () => {
 
         expect(data.id).toBe(mailAccountID);
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -743,8 +840,8 @@ describe("Mail Account Routes", async () => {
             body: updatedData
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -796,8 +893,8 @@ describe("Mail Account Routes", async () => {
             body: updatedData
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -859,8 +956,8 @@ describe("Mail Account Routes", async () => {
             authToken: session_token,
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).get();
 
         expect(dbresult).toBeUndefined();
@@ -879,8 +976,8 @@ describe("Mail Account Routes", async () => {
     afterAll(async () => {
         SessionHandler.inValidateAllSessionsForUser(mailAccountTestUser.id);
 
-        DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, mailAccountTestUser.id)
+        DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, mailAccountTestUser.id)
         ).run();
     });
 
@@ -918,8 +1015,8 @@ describe("Mail Identity Routes", async () => {
 
         expect(data.id).toBeGreaterThan(0);
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.id, data.id)
+        const dbresult = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.id, data.id)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -941,9 +1038,9 @@ describe("Mail Identity Routes", async () => {
 
         expect(Array.isArray(data)).toBe(true);
 
-        const dbresults = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.mail_account_id, mailAccountID)
-        ).orderBy(desc(DB.Schema.mailIdentities.id)).all();
+        const dbresults = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.mail_account_id, mailAccountID)
+        ).orderBy(desc(DB.Tables.mailIdentities.id)).all();
 
         expect(data.length).toBe(dbresults.length);
 
@@ -975,8 +1072,8 @@ describe("Mail Identity Routes", async () => {
 
         expect(data.id).toBe(mailIdentityID);
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.id, mailIdentityID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.id, mailIdentityID)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -1014,8 +1111,8 @@ describe("Mail Identity Routes", async () => {
             body: updatedData
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.id, mailIdentityID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.id, mailIdentityID)
         ).get();
 
         expect(dbresult).toBeDefined();
@@ -1054,8 +1151,8 @@ describe("Mail Identity Routes", async () => {
             authToken: session_token,
         });
 
-        const dbresult = DB.instance().select().from(DB.Schema.mailIdentities).where(
-            eq(DB.Schema.mailIdentities.id, mailIdentityID)
+        const dbresult = DB.instance().select().from(DB.Tables.mailIdentities).where(
+            eq(DB.Tables.mailIdentities.id, mailIdentityID)
         ).get();
 
         expect(dbresult).toBeUndefined();
@@ -1076,12 +1173,12 @@ describe("Mail Identity Routes", async () => {
 
         SessionHandler.inValidateAllSessionsForUser(mailIdentityTestUser.id);
 
-        DB.instance().delete(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        DB.instance().delete(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).run();
 
-        DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, mailIdentityTestUser.id)
+        DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, mailIdentityTestUser.id)
         ).run();
     });
 });
@@ -1140,7 +1237,7 @@ describe("Mail Mailbox Routes", async () => {
             throw new Error("Failed to encrypt mail account data");
         }
 
-        mailAccountID = DB.instance().insert(DB.Schema.mailAccounts).values({
+        mailAccountID = DB.instance().insert(DB.Tables.mailAccounts).values({
             owner_user_id: mailIdentityTestUser.id,
             display_name: "Test Mail Account",
             smtp_encrypted_connection_data: encryptedSMTPData,
@@ -1347,7 +1444,7 @@ describe("Mail Mailbox Mails Routes", async () => {
             throw new Error("Failed to encrypt mail account data");
         }
 
-        mailAccountID = DB.instance().insert(DB.Schema.mailAccounts).values({
+        mailAccountID = DB.instance().insert(DB.Tables.mailAccounts).values({
             owner_user_id: mailIdentityTestUser.id,
             display_name: "Test Mail Account",
             smtp_encrypted_connection_data: encryptedSMTPData,
@@ -1914,7 +2011,7 @@ describe("Mail Search Routes", async () => {
             throw new Error("Failed to encrypt mail account data");
         }
 
-        mailAccountID = DB.instance().insert(DB.Schema.mailAccounts).values({
+        mailAccountID = DB.instance().insert(DB.Tables.mailAccounts).values({
             owner_user_id: searchTestUser.id,
             display_name: "Test Mail Account",
             smtp_encrypted_connection_data: encryptedSMTPData,
@@ -1927,12 +2024,12 @@ describe("Mail Search Routes", async () => {
 
         SessionHandler.inValidateAllSessionsForUser(searchTestUser.id);
 
-        DB.instance().delete(DB.Schema.mailAccounts).where(
-            eq(DB.Schema.mailAccounts.id, mailAccountID)
+        DB.instance().delete(DB.Tables.mailAccounts).where(
+            eq(DB.Tables.mailAccounts.id, mailAccountID)
         ).run();
 
-        DB.instance().delete(DB.Schema.users).where(
-            eq(DB.Schema.users.id, searchTestUser.id)
+        DB.instance().delete(DB.Tables.users).where(
+            eq(DB.Tables.users.id, searchTestUser.id)
         ).run();
     });
 

--- a/tests/email.test.ts
+++ b/tests/email.test.ts
@@ -1,0 +1,239 @@
+import { beforeAll, afterAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { DB } from "../src/db";
+import { EmailService, type CapturedEmail } from "../src/api/utils/email";
+import { hashResetToken } from "../src/api/versions/v1/routes/auth/reset-password";
+import { makeAPIRequest } from "./helpers/api";
+import { seedUser, seedSession } from "./helpers/seed";
+import { createMemoryTransport } from "./helpers/memory-transport";
+import type { SeededUser } from "./helpers/seed";
+import { AuthModel } from "../src/api/versions/v1/routes/auth/model";
+
+/** Emails captured by the in-memory transport, isolated to this file. */
+const capturedEmails: CapturedEmail[] = [];
+
+describe("EmailService", () => {
+
+    beforeAll(() => {
+        // Inject the memory transport so we can assert on sent emails
+        EmailService.init(createMemoryTransport(capturedEmails));
+    });
+
+    afterAll(() => {
+        // Restore to unconfigured so other test files are unaffected
+        EmailService.reset();
+    });
+
+    test("isEnabled() returns true when memory transport is injected", () => {
+        expect(EmailService.isEnabled()).toBe(true);
+    });
+
+    test("starts with no captured emails", () => {
+        expect(capturedEmails).toHaveLength(0);
+    });
+});
+
+describe("Password reset email integration", () => {
+
+    let resetUser: SeededUser;
+    let resetSessionToken: string;
+
+    beforeAll(async () => {
+        // Ensure the memory transport is active for this describe block too.
+        // Re-init is idempotent as long as we pass the same output array.
+        EmailService.init(createMemoryTransport(capturedEmails));
+
+        resetUser = await seedUser("user");
+        resetSessionToken = await seedSession(resetUser.id);
+        capturedEmails.length = 0;
+    });
+
+    afterAll(() => {
+        EmailService.reset();
+    });
+
+    test("POST /auth/reset-password/request sends email for existing user", async () => {
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: resetUser.email },
+        }, 200);
+
+        expect(capturedEmails).toHaveLength(1);
+        expect(capturedEmails[0]!.to).toBe(resetUser.email);
+        expect(capturedEmails[0]!.subject).toBe("Delivr — Password Reset Request");
+    });
+
+    test("Email contains a valid reset link with token", async () => {
+        // Use a fresh user to avoid rate-limiting from the previous test
+        const freshUser = await seedUser("user");
+        capturedEmails.length = 0;
+
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: freshUser.email },
+        }, 200);
+
+        expect(capturedEmails).toHaveLength(1);
+
+        const html = capturedEmails[0]!.html;
+        // Extract the reset URL from the HTML
+        const urlMatch = html.match(/href="([^"]*reset-password\?token=[^"]+)"/);
+        expect(urlMatch).not.toBeNull();
+
+        const resetUrl = urlMatch![1]!;
+        const urlObj = new URL(resetUrl);
+        const token = urlObj.searchParams.get("token");
+        expect(token).not.toBeNull();
+        expect(token!.length).toBeGreaterThan(0);
+
+        // Verify the token is stored in DB (HMAC'd)
+        const hashed = hashResetToken(token!);
+        const dbToken = DB.instance().select().from(DB.Tables.passwordResets)
+            .where(eq(DB.Tables.passwordResets.token, hashed))
+            .get();
+        expect(dbToken).not.toBeNull();
+    });
+
+    test("POST /auth/reset-password/request does NOT send email for unknown user", async () => {
+        capturedEmails.length = 0;
+
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: `nope-${randomUUID()}@example.com` },
+        }, 200);
+
+        expect(capturedEmails).toHaveLength(0);
+    });
+
+    test("Rate limit prevents duplicate emails within the window", async () => {
+        const rateLimitUser = await seedUser("user");
+        capturedEmails.length = 0;
+
+        // First request — should send email
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: rateLimitUser.email },
+        }, 200);
+
+        expect(capturedEmails).toHaveLength(1);
+
+        // Second request for same email — rate limited, no email
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: rateLimitUser.email },
+        }, 200);
+
+        expect(capturedEmails).toHaveLength(1);
+    });
+
+    test("Authenticated users cannot request reset and no email is sent", async () => {
+        capturedEmails.length = 0;
+
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            authToken: resetSessionToken,
+            body: { email: resetUser.email },
+        }, 401);
+
+        expect(capturedEmails).toHaveLength(0);
+    });
+
+    test("Full reset flow: request → extract token from email → consume token → password changed", async () => {
+        const flowUser = await seedUser("user");
+        capturedEmails.length = 0;
+
+        const newPassword = "N3wP@ssw0rd!";
+
+        // 1. Request reset
+        await makeAPIRequest("/v1/auth/reset-password/request", {
+            method: "POST",
+            body: { email: flowUser.email },
+        }, 200);
+
+        // 2. Extract token from captured email
+        expect(capturedEmails).toHaveLength(1);
+        const urlMatch = capturedEmails[0]!.html.match(/href="([^"]*reset-password\?token=[^"]+)"/);
+        expect(urlMatch).not.toBeNull();
+        const token = new URL(urlMatch![1]!).searchParams.get("token")!;
+
+        // 3. Create a session before consuming the token — it should be invalidated
+        const oldSession = await seedSession(flowUser.id);
+
+        // 4. Consume the token (this invalidates all sessions for the user)
+        await makeAPIRequest("/v1/auth/reset-password", {
+            method: "POST",
+            body: {
+                reset_token: token,
+                new_password: newPassword,
+            },
+        }, 200);
+
+        // 5. Verify old session is invalidated
+        await makeAPIRequest("/v1/auth/session", { authToken: oldSession }, 401);
+
+        // 6. Verify new password works
+        const login = await makeAPIRequest("/v1/auth/login", {
+            method: "POST",
+            body: {
+                username: flowUser.username,
+                password: newPassword,
+            },
+            expectedBodySchema: AuthModel.Login.Response
+        }, 200);
+
+        expect(login).not.toBeNull();
+        if (!login) return;
+
+        expect(login.token).toStartWith("dla_sess_");
+    });
+
+    test("Expired reset token is rejected", async () => {
+        const expiredUser = await seedUser("user");
+        capturedEmails.length = 0;
+
+        const expiredToken = `expired_${randomUUID().replace(/-/g, "")}`;
+        await DB.instance().insert(DB.Tables.passwordResets).values({
+            token: hashResetToken(expiredToken),
+            user_id: expiredUser.id,
+            expires_at: Date.now() - 1000, // 1 second in the past
+        }).run();
+
+        await makeAPIRequest("/v1/auth/reset-password", {
+            method: "POST",
+            body: {
+                reset_token: expiredToken,
+                new_password: "N3wP@ssw0rd!",
+            },
+        }, 400);
+    });
+
+    test("Consuming a reset token deletes all tokens for that user", async () => {
+        const multiTokenUser = await seedUser("user");
+        capturedEmails.length = 0;
+
+        const token1 = `multi_${randomUUID().replace(/-/g, "")}`;
+        const token2 = `multi_${randomUUID().replace(/-/g, "")}`;
+
+        await DB.instance().insert(DB.Tables.passwordResets).values([
+            { token: hashResetToken(token1), user_id: multiTokenUser.id, expires_at: Date.now() + 600_000 },
+            { token: hashResetToken(token2), user_id: multiTokenUser.id, expires_at: Date.now() + 600_000 },
+        ]).run();
+
+        // Consume token1
+        await makeAPIRequest("/v1/auth/reset-password", {
+            method: "POST",
+            body: {
+                reset_token: token1,
+                new_password: "An0therP@ss!",
+            },
+        }, 200);
+
+        // Both tokens should be gone
+        const remaining = DB.instance().select().from(DB.Tables.passwordResets)
+            .where(eq(DB.Tables.passwordResets.user_id, multiTokenUser.id))
+            .all();
+        expect(remaining).toHaveLength(0);
+    });
+
+});

--- a/tests/helpers/memory-transport.ts
+++ b/tests/helpers/memory-transport.ts
@@ -1,0 +1,37 @@
+import nodemailer from "nodemailer";
+import type { Transporter } from "nodemailer";
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import type { CapturedEmail } from "../../src/api/utils/email";
+
+/**
+ * Build an in-memory nodemailer transport that captures every sent email
+ * into the provided array instead of delivering it over SMTP.
+ *
+ * Usage:
+ *   const emails: CapturedEmail[] = [];
+ *   const transport = createMemoryTransport(emails);
+ *   EmailService.init(transport);
+ */
+export function createMemoryTransport(capture: CapturedEmail[]): Transporter {
+    return nodemailer.createTransport({
+        name: "memory",
+        version: "1.0.0",
+        send: (mail: MailMessage, callback: (err: Error | null, info: any) => void) => {
+            capture.push({
+                from: (mail.data.from as string) ?? "",
+                to: (Array.isArray(mail.data.to) ? mail.data.to.join(", ") : mail.data.to ?? "") as string,
+                subject: (mail.data.subject as string) ?? "",
+                html: (mail.data.html as string) ?? "",
+                text: (mail.data.text as string) ?? "",
+            });
+            callback(null, {
+                messageId: `mock-${Date.now()}@memory`,
+                envelope: { from: mail.data.from as string, to: [mail.data.to as string].flat() },
+                accepted: [mail.data.to as string].flat(),
+                rejected: [],
+                pending: [],
+                response: "250 OK (memory)",
+            });
+        },
+    } as any);
+}

--- a/tests/helpers/preload.ts
+++ b/tests/helpers/preload.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { afterAll, beforeAll } from "bun:test";
-import { ConfigHandler } from "../../src/utils/config";
+import { ConfigHandler, type ParsedConfig } from "../../src/utils/config";
 import { DB } from "../../src/db";
 import { API } from "../../src/api";
 import { MockIMAPServer } from "./mock-mail-servers/imap/server";
@@ -12,21 +12,36 @@ import { MailAccountEncryption } from "../../src/utils/crypto/mailCrypt";
 // Allow overriding the env file used for tests without clobbering existing env vars.
 const TEST_ENV_FILE = process.env.TEST_ENV_FILE ?? ".env.local";
 
-async function loadTestEnv(filePath: string) {
-    try {
-        const content = await Bun.file(filePath).text();
-        for (const rawLine of content.split(/\r?\n/)) {
-            const line = rawLine.trim();
-            if (!line || line.startsWith("#")) continue;
-            const [key, ...rest] = line.split("=");
-            if (!key) continue;
-            const value = rest.join("=").trim();
-            if (process.env[key] === undefined) {
-                process.env[key] = value;
-            }
-        }
-    } catch (err: any) {
-        if (err?.code !== "ENOENT") throw err;
+function setTestEnv(rootDir: string) {
+
+    const envVars = {
+        DLA_LOG_LEVEL: "debug",
+
+        DLA_APP_URL: "http://localhost:12153",
+        
+        DLA_API_HOST: "::",
+        DLA_API_PORT: "1",
+        DLA_DISABLE_DOCS: true,
+
+        DLA_ENCRYPTION_KEY: "67e3d03dc88682553deed5fa4484bd80a500783850efbb49f6912ad0935eedeb",
+
+        DLA_LOG_DIR: path.join(rootDir, "logs"),
+        DLA_CONFIG_BASE_DIR: rootDir,
+
+        DLA_DB_CONNECTION_URL: path.join(rootDir, "db.sqlite"),
+        DLA_DB_AUTO_MIGRATE: true,
+
+        DLA_SMTP_HOST: "127.0.0.1",
+        DLA_SMTP_PORT: "12587",
+        DLA_SMTP_USERNAME: "",
+        DLA_SMTP_PASSWORD: "",
+        DLA_SMTP_FROM: "\"Delivr Test\" <test@delivr.local>",
+        DLA_SMTP_SECURE: false,
+
+    } as const satisfies ParsedConfig;
+
+    for (const [key, value] of Object.entries(envVars)) {
+        process.env[key] = String(value);
     }
 }
 
@@ -131,10 +146,12 @@ const mockIMAPServer = new MockIMAPServer({
 });
 
 
-beforeAll(async () => {
-    await loadTestEnv(TEST_ENV_FILE);
-    
+beforeAll(async () => {    
     TMP_ROOT = await createIsolatedDataDir();
+
+    setTestEnv(TMP_ROOT);
+
+    const config = await ConfigHandler.loadConfig();
 
     const encryptionKey = LCrypt.randomBytes(32).toString("hex");
     MailAccountEncryption.init(encryptionKey);
@@ -144,6 +161,9 @@ beforeAll(async () => {
         true,
         TMP_ROOT
     );
+
+    // EmailService is NOT initialised here — tests that need it call
+    // EmailService.init(mockTransport) in their own beforeAll.
 
     mockIMAPServer.listen(11143);
 

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from "crypto";
+import { DB } from "../../src/db";
+import { SessionHandler } from "../../src/api/utils/authHandler";
+
+export type SeededUser = Omit<DB.Models.User, "password_hash"> & { password: string };
+
+const DEFAULT_PASSWORD = "TestP@ssw0rd";
+
+export async function seedUser(
+    role: DB.Models.User["role"] = "user",
+    overrides: Partial<DB.Models.User> = {},
+    password: string = DEFAULT_PASSWORD
+): Promise<SeededUser> {
+    const user = DB.instance().insert(DB.Tables.users).values({
+        username: overrides.username ?? `user_${randomUUID().slice(0, 8)}`,
+        display_name: overrides.display_name ?? "Test User",
+        email: overrides.email ?? `${randomUUID()}@example.com`,
+        password_hash: await Bun.password.hash(password),
+        role,
+    } as any).returning().get();
+
+    return { ...user, password };
+}
+
+export async function seedSession(user_id: number): Promise<string> {
+    const session = await SessionHandler.createSession(user_id);
+    return session.token;
+}
+


### PR DESCRIPTION
- Updated all instances in PostgreSQL and SQLite schema files to use DB.Tables instead of DB.Schema for user, password resets, sessions, API keys, mail accounts, mail identities, metadata, and user preferences.
- Introduced EmailService for handling email functionalities, including password reset emails.
- Added configuration options for SMTP settings in the config handler.
- Implemented tests for email service and password reset functionality, including integration tests for email sending and token validation.
- Created memory transport for testing email sending without a live SMTP server.
- Added helper functions for seeding users and sessions in tests.