### PR TITLE
docs: refresh CLAUDE.md, README, and OpenAPI tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,12 @@ src/
 │           ├── middleware/
 │           │   └── auth.ts
 │           ├── docs/
-│           │   └── index.ts  # Scalar API reference
-│           └── routes/       # Route modules (auth, account, mail-accounts, admin)
-│                              #   mail-accounts → mailboxes → mails → attachments (nested)
+│           │   └── index.ts  # OpenAPI tag definitions (DOCS_TAGS)
+│           └── routes/       # Route modules (auth, account, mail-accounts, bimi, admin)
+│                              #   auth → reset-password
+│                              #   account → apikeys, preferences
+│                              #   mail-accounts → identities, search, mailboxes (nested)
+│                              #     mailboxes → mail-bulk-actions, mails → attachments
 ├── db/
 │   ├── index.ts              # DB connection setup
 │   ├── utils.ts              # DB utilities
@@ -73,7 +76,7 @@ src/
 ## Key Conventions
 
 - **API versioning**: Routes live under `src/api/versions/v{n}/routes/`. Each route module has an `index.ts` (router) and `model.ts` (Zod schemas).
-- **OpenAPI specs**: Use `hono-openapi` decorators on route handlers. Spec helpers in `specHelpers.ts`.
+- **OpenAPI specs**: Use `hono-openapi` decorators on route handlers via `APIRouteSpec`/`APIResponseSpec` helpers in `specHelpers.ts` (`summary`, `description`, `tags`). Tags come from `DOCS_TAGS` in `versions/v1/docs/index.ts`. When adding a new tag, also register it in the `tags` array **and** an `x-tagGroups` group in `versions/v1/index.ts`, or it renders orphaned in Scalar. The spec is served at `/docs/v1/openapi` and the Scalar UI at `/docs/v1` (both mounted in `api/index.ts`, gated by `DLA_DISABLE_DOCS`).
 - **Database**: Schema files are per-dialect in `src/db/schema/`. Migrations managed via Drizzle Kit.
 - **Auth**: JWT-based auth via `authHandler.ts`. Middleware in `src/api/versions/v1/middleware/auth.ts`.
 - **Validation**: Zod schemas in `model.ts` files, validated via `@hono/standard-validator`.
@@ -88,4 +91,8 @@ src/
 - **Mail parsing is metadata-only**: `MailParser.parseMail` (via `postal-mime`) intentionally strips attachment *content*, keeping only metadata (`id`, `filename`, `contentType`, `size`, `contentId`, `contentDisposition`). The `id` is the attachment's index within the mail and is the handle used to fetch its bytes.
 - **Attachment content is never stored or cached server-side**: the `attachments/:attachmentId` route re-fetches the message source from IMAP, parses it transiently in-memory (`MailParser.getAttachmentContent`), and streams the single attachment out with `Cache-Control: no-store` (+ `nosniff`). `MailClientsCache` pools IMAP *connections* only, never message/attachment data.
 - Drizzle schema files are dialect-specific — changes should be mirrored across all three when adding new tables/columns.
+- **User preferences are schemaless rows**, not columns: the `user_preferences` table stores one row per `(user_id, key)` with the value in a JSON `data` column. Both the remote-content-policy and auto-mark-as-seen preferences live here (keyed strings), accessed via `UserPreferencesHandler` (`utils/preferences.ts`). Adding a preference does **not** require a migration.
+- **BIMI is resolved live, never persisted**: the `bimi/:domain` route uses `BimiService` to read the sender domain's BIMI DNS record and return the brand `logoUrl`. Only DNS metadata is read — the logo SVG is never fetched or stored server-side; the client loads it directly.
+- **Bulk mail actions** (`mailboxes/.../mail-bulk-actions`) apply move/copy/delete/flag operations to many UIDs in a single IMAP round-trip, separate from the per-mail routes under `mails/`.
+- **Outbound system mail** (e.g. password-reset emails) uses the `DLA_SMTP_*` config vars — distinct from the per-account IMAP/SMTP credentials stored encrypted in `mail_accounts`.
 - The `data/` directory contains runtime data (SQLite DB files, etc.).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ speaking IMAP and SMTP so your inbox stays yours.
 - 📬 **Real mail, real protocols** — connects to any IMAP/SMTP provider via [`imapflow`](https://github.com/postalsys/imapflow) and [`nodemailer`](https://nodemailer.com); nothing proprietary in the way.
 - 🗂️ **Nested mail resources** — mail accounts → mailboxes → mails → attachments, modelled cleanly all the way down.
 - 📎 **Privacy-first attachments** — content is **never stored or cached** server-side. Attachments are re-fetched from IMAP, parsed in-memory, and streamed out with `Cache-Control: no-store`.
+- ⚡ **Bulk mail actions** — move, copy, delete, and flag many messages in one request.
+- 🖼️ **BIMI brand logos** — resolves sender brand logos from DNS for use as profile pictures; only record metadata is read, the logo is never fetched or stored.
 - 🔐 **JWT auth + API keys** — token-based sessions plus scoped API keys for programmatic access.
 - 🔒 **ECC crypto** — mail-backend credentials protected with elliptic-curve encryption and signing.
 - 📖 **First-class OpenAPI** — every route is documented via `hono-openapi` and browsable through an embedded [Scalar](https://scalar.com) reference.
@@ -68,7 +70,7 @@ bun run db:sqlite:migrate
 bun run dev
 ```
 
-The API is now live at **http://localhost:14123**, with interactive docs at **`/v1/docs`** (unless `DLA_DISABLE_DOCS=true`).
+The API is now live at **http://localhost:14123**, with the interactive [Scalar](https://scalar.com) reference at **`/docs/v1`** and the raw OpenAPI spec at **`/docs/v1/openapi`** (unless `DLA_DISABLE_DOCS=true`). The root path `/` redirects to the latest version's docs.
 
 ## ⚙️ Configuration
 
@@ -77,15 +79,21 @@ All configuration is environment-based (see [`example.env`](./example.env)):
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DLA_LOG_LEVEL` | Log verbosity | `info` |
-| `DLA_APP_URL` | URL of the Delivr web client | — |
+| `DLA_APP_URL` | **Required.** URL of the Delivr web client | — |
 | `DLA_API_HOST` | Bind address | `::` |
 | `DLA_API_PORT` | Listen port | `14123` |
 | `DLA_DISABLE_DOCS` | Disable the Scalar API reference | `false` |
-| `DLA_ENCRYPTION_KEY` | **32-character** key for credential encryption | — |
+| `DLA_ENCRYPTION_KEY` | **Required. 32-character** key for credential encryption | — |
 | `DLA_DB_CONNECTION_URL` | Database connection string / path | `./data/db.sqlite` |
 | `DLA_DB_AUTO_MIGRATE` | Run migrations on startup | `true` |
 | `DLA_LOG_DIR` | Log output directory | `./data/logs` |
 | `DLA_CONFIG_BASE_DIR` | Config base directory | `./config` |
+| `DLA_SMTP_HOST` | Outbound SMTP host for system mail (e.g. password-reset emails) | — |
+| `DLA_SMTP_PORT` | Outbound SMTP port | — |
+| `DLA_SMTP_USERNAME` | Outbound SMTP username | — |
+| `DLA_SMTP_PASSWORD` | Outbound SMTP password | — |
+| `DLA_SMTP_FROM` | `From` address for system mail | — |
+| `DLA_SMTP_SECURE` | Use TLS for the SMTP connection | `false` |
 
 ## 🛠️ Commands
 
@@ -111,9 +119,12 @@ src/
 │   ├── utils/              # Response helpers, auth, OpenAPI, services
 │   └── versions/v1/
 │       ├── middleware/     # Auth middleware
-│       ├── docs/           # Scalar API reference
-│       └── routes/         # auth · account · mail-accounts · admin
-│                           #   mail-accounts → mailboxes → mails → attachments
+│       ├── docs/           # OpenAPI tag definitions (Scalar UI mounted in api/index.ts)
+│       └── routes/         # auth · account · mail-accounts · bimi · admin
+│                           #   auth → reset-password
+│                           #   account → apikeys · preferences
+│                           #   mail-accounts → identities · search · mailboxes
+│                           #     mailboxes → mail-bulk-actions · mails → attachments
 ├── db/
 │   ├── index.ts            # DB connection
 │   └── schema/             # Per-dialect Drizzle schema (sqlite · postgresql · mysql)

--- a/example.env
+++ b/example.env
@@ -13,3 +13,12 @@ DLA_CONFIG_BASE_DIR=./config
 
 DLA_DB_CONNECTION_URL=./data/db.sqlite
 DLA_DB_AUTO_MIGRATE=true
+
+# Outbound SMTP — used for system mail such as password-reset emails.
+# All optional; leave unset to disable outbound system mail.
+DLA_SMTP_HOST=
+DLA_SMTP_PORT=
+DLA_SMTP_USERNAME=
+DLA_SMTP_PASSWORD=
+DLA_SMTP_FROM=
+DLA_SMTP_SECURE=false

--- a/src/api/versions/v1/index.ts
+++ b/src/api/versions/v1/index.ts
@@ -73,6 +73,7 @@ const openAPIConfig: Partial<GenerateSpecOptions> = {
                     "Mail Accounts / Mailboxes",
                     "Mail Accounts / Mailboxes / Mails",
                     "Mail Accounts / Mailboxes / Mails / Attachments",
+                    "Mail Accounts / Mailboxes / Mail Bulk Actions",
                     "BIMI"
                 ]
             }
@@ -162,6 +163,14 @@ const openAPIConfig: Partial<GenerateSpecOptions> = {
                 summary: "Mail Attachments",
                 parent: "Mail Accounts / Mailboxes / Mails",
                 description: "Endpoints for listing and downloading mail attachments. Attachment content is fetched from the mail server and streamed on demand — it is never stored or cached on the API server.",
+            },
+            {
+                name: "Mail Accounts / Mailboxes / Mail Bulk Actions",
+                // @ts-ignore
+                "x-displayName": "Bulk Actions",
+                summary: "Mail Bulk Actions",
+                parent: "Mail Accounts / Mailboxes",
+                description: "Endpoints for applying move, copy, delete, and flag operations to many messages in a single request.",
             },
             {
                 name: "BIMI",


### PR DESCRIPTION
- Register the orphaned "Mail Bulk Actions" OpenAPI tag in x-tagGroups and the tags array so it no longer renders detached in Scalar
- Fix the docs path in the README (/docs/v1, not /v1/docs) and document the DLA_SMTP_* outbound-mail vars in the README table and example.env
- Refresh CLAUDE.md route tree and architecture notes (preferences, BIMI, bulk actions, system SMTP)