### PR TITLE
feat: persist special-use folder mapping and detect on the backend

### DIFF
--- a/drizzle/migrations/sqlite/0011_worthless_tomas.sql
+++ b/drizzle/migrations/sqlite/0011_worthless_tomas.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `mail_account_special_use` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`mail_account_id` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`data` text NOT NULL,
+	FOREIGN KEY (`mail_account_id`) REFERENCES `mail_accounts`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `mail_account_special_use_account_unique` ON `mail_account_special_use` (`mail_account_id`);

--- a/drizzle/migrations/sqlite/meta/0011_snapshot.json
+++ b/drizzle/migrations/sqlite/meta/0011_snapshot.json
@@ -1,0 +1,611 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "985cd33e-5486-4fe8-85e0-d25ff2b348e9",
+  "prevId": "fe6f4a33-12a6-4df4-bbfd-4494fde69dab",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_user_role_users_role_fk": {
+          "name": "api_keys_user_role_users_role_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mail_account_special_use": {
+      "name": "mail_account_special_use",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mail_account_id": {
+          "name": "mail_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mail_account_special_use_account_unique": {
+          "name": "mail_account_special_use_account_unique",
+          "columns": [
+            "mail_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mail_account_special_use_mail_account_id_mail_accounts_id_fk": {
+          "name": "mail_account_special_use_mail_account_id_mail_accounts_id_fk",
+          "tableFrom": "mail_account_special_use",
+          "tableTo": "mail_accounts",
+          "columnsFrom": [
+            "mail_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mail_accounts": {
+      "name": "mail_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "smtp_encrypted_connection_data": {
+          "name": "smtp_encrypted_connection_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imap_encrypted_connection_data": {
+          "name": "imap_encrypted_connection_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_accounts_owner_user_id_users_id_fk": {
+          "name": "mail_accounts_owner_user_id_users_id_fk",
+          "tableFrom": "mail_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mail_identities": {
+      "name": "mail_identities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mail_account_id": {
+          "name": "mail_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_identities_mail_account_id_mail_accounts_id_fk": {
+          "name": "mail_identities_mail_account_id_mail_accounts_id_fk",
+          "tableFrom": "mail_identities",
+          "tableTo": "mail_accounts",
+          "columnsFrom": [
+            "mail_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata": {
+      "name": "metadata",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_resets": {
+      "name": "password_resets",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_resets_user_id_users_id_fk": {
+          "name": "password_resets_user_id_users_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_user_role_users_role_fk": {
+          "name": "sessions_user_role_users_role_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_role"
+          ],
+          "columnsTo": [
+            "role"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_preferences_user_id_key_unique": {
+          "name": "user_preferences_user_id_key_unique",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/sqlite/meta/_journal.json
+++ b/drizzle/migrations/sqlite/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782943361675,
       "tag": "0010_strong_rocket_racer",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1783286464696,
+      "tag": "0011_worthless_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/src/api/utils/services/specialUseService.ts
+++ b/src/api/utils/services/specialUseService.ts
@@ -1,0 +1,204 @@
+import { eq } from "drizzle-orm";
+import { DB } from "../../../db";
+import { MailboxRessource } from "../../../utils/mails/ressources/mailbox";
+
+/**
+ * Special-use folder detection and per-account persistence.
+ *
+ * The backend resolves each account's special folders once (server-advertised
+ * IMAP `\Flag` first, then multilingual name heuristics), stores the result and
+ * reuses it, so neither it nor the client re-guesses on every request. Users can
+ * override individual mappings; overrides are preserved across re-detection as
+ * long as the target folder still exists.
+ */
+export namespace SpecialUse {
+
+    // Inbox is fixed by the server; the rest are user-reassignable.
+    export const TYPES = ['inbox', 'drafts', 'sent', 'spam', 'trash', 'archive'] as const;
+    export type Type = (typeof TYPES)[number];
+
+    export const EDITABLE_TYPES = ['drafts', 'sent', 'spam', 'trash', 'archive'] as const;
+    export type EditableType = (typeof EDITABLE_TYPES)[number];
+
+    export type Source = 'flag' | 'guess' | 'user';
+    export interface Entry { path: string; source: Source; }
+    export type Mapping = Partial<Record<Type, Entry>>;
+
+    // The IMAP SPECIAL-USE flag stored in `specialUse` for each type.
+    export const FLAG: Record<Type, string> = {
+        inbox: '\\Inbox',
+        drafts: '\\Drafts',
+        sent: '\\Sent',
+        spam: '\\Junk',
+        trash: '\\Trash',
+        archive: '\\Archive',
+    };
+
+    const MANAGED_FLAGS = new Set(Object.values(FLAG));
+
+    // Leaf-name heuristics (lowercased) per type, covering common English and
+    // localized folder names. Used only when the server advertises no flag.
+    const NAMES: Record<Type, Set<string>> = {
+        inbox: new Set(['inbox']),
+        drafts: new Set([
+            'drafts', 'draft', 'entwürfe', 'entwurfe', 'brouillons', 'borradores',
+            'bozze', 'concepten', 'utkast', 'wersje robocze', 'rascunhos',
+        ]),
+        sent: new Set([
+            'sent', 'sent mail', 'sent messages', 'sent items', 'gesendet',
+            'gesendete', 'gesendete elemente', 'envoyés', 'envoyes', 'enviados',
+            'inviati', 'verzonden', 'skickat', 'wysłane', 'itens enviados',
+        ]),
+        spam: new Set([
+            'spam', 'junk', 'junk mail', 'junk e-mail', 'bulk mail', 'unerwünscht',
+            'unerwunscht', 'pourriel', 'correo no deseado', 'posta indesiderata',
+            'ongewenst',
+        ]),
+        trash: new Set([
+            'trash', 'deleted', 'deleted items', 'deleted messages', 'bin',
+            'recycle bin', 'papierkorb', 'corbeille', 'papelera', 'cestino',
+            'prullenbak', 'lixeira', 'kosz', 'papperskorg',
+        ]),
+        archive: new Set([
+            'archive', 'archives', 'all mail', 'archiv', 'archivo', 'archivio',
+            'archief', 'arkiv', 'archiwum', 'arquivo',
+        ]),
+    };
+
+    function leafName(mb: MailboxRessource): string {
+        const delimiter = mb.delimiter || '/';
+        return (mb.path.split(delimiter).pop() ?? mb.path).toLowerCase();
+    }
+
+    /** Detect a single type: server flag first, then leaf-name heuristics. */
+    export function detectType(type: Type, mailboxes: MailboxRessource[]): Entry | undefined {
+        const byFlag = mailboxes.find((mb) => mb.specialUse === FLAG[type]);
+        if (byFlag) return { path: byFlag.path, source: 'flag' };
+
+        const names = NAMES[type];
+        const byName = mailboxes.find((mb) => names.has(leafName(mb)) || names.has(mb.path.toLowerCase()));
+        if (byName) return { path: byName.path, source: 'guess' };
+
+        return undefined;
+    }
+
+    /**
+     * Reconcile a mapping against the current folder list: keep still-valid user
+     * overrides, re-detect everything else.
+     */
+    export function reconcile(existing: Mapping | null, mailboxes: MailboxRessource[]): Mapping {
+        const paths = new Set(mailboxes.map((mb) => mb.path));
+        const result: Mapping = {};
+
+        for (const type of TYPES) {
+            const prev = existing?.[type];
+            // A user override survives only while its target folder still exists.
+            if (prev?.source === 'user' && paths.has(prev.path)) {
+                result[type] = prev;
+                continue;
+            }
+            const detected = detectType(type, mailboxes);
+            if (detected) result[type] = detected;
+        }
+
+        return result;
+    }
+
+    /**
+     * Rewrite each mailbox's `specialUse` to match the mapping so the client can
+     * trust it verbatim. Managed flags not backed by the mapping are cleared so
+     * there is never more than one folder of a given type.
+     */
+    export function apply(mailboxes: MailboxRessource[], mapping: Mapping): MailboxRessource[] {
+        const pathToFlag = new Map<string, string>();
+        for (const type of TYPES) {
+            const entry = mapping[type];
+            if (entry) pathToFlag.set(entry.path, FLAG[type]);
+        }
+
+        return mailboxes.map((mb) => {
+            const mapped = pathToFlag.get(mb.path);
+            if (mapped) return new MailboxRessource({ ...mb, specialUse: mapped });
+            if (mb.specialUse && MANAGED_FLAGS.has(mb.specialUse)) {
+                return new MailboxRessource({ ...mb, specialUse: undefined });
+            }
+            return mb;
+        });
+    }
+}
+
+export class SpecialUseHandler {
+
+    /** The stored mapping for an account, or null if none has been persisted yet. */
+    static async getStored(accountId: number): Promise<SpecialUse.Mapping | null> {
+        const row = await DB.instance().select().from(DB.Tables.mailAccountSpecialUse).where(
+            eq(DB.Tables.mailAccountSpecialUse.mail_account_id, accountId)
+        ).get();
+        return row ? (row.data as SpecialUse.Mapping) : null;
+    }
+
+    private static async store(accountId: number, mapping: SpecialUse.Mapping): Promise<void> {
+        await DB.instance().insert(DB.Tables.mailAccountSpecialUse).values({
+            mail_account_id: accountId,
+            data: mapping,
+        }).onConflictDoUpdate({
+            target: DB.Tables.mailAccountSpecialUse.mail_account_id,
+            set: { data: mapping },
+        });
+    }
+
+    /**
+     * Resolve, persist and return the mapping for an account: (re)detects from the
+     * current folder list while preserving valid user overrides. Single entry
+     * point used by mailbox listing and after folder mutations.
+     */
+    static async resolve(accountId: number, mailboxes: MailboxRessource[]): Promise<SpecialUse.Mapping> {
+        const existing = await this.getStored(accountId);
+        const reconciled = SpecialUse.reconcile(existing, mailboxes);
+        await this.store(accountId, reconciled);
+        return reconciled;
+    }
+
+    /** Return the mailbox list with `specialUse` normalized against the mapping. */
+    static async applyToMailboxes(accountId: number, mailboxes: MailboxRessource[]): Promise<MailboxRessource[]> {
+        const mapping = await this.resolve(accountId, mailboxes);
+        return SpecialUse.apply(mailboxes, mapping);
+    }
+
+    /**
+     * Apply user overrides. Each editable type maps to a folder path, or `null`
+     * to clear the override and revert that type to auto-detection.
+     */
+    static async setOverrides(
+        accountId: number,
+        mailboxes: MailboxRessource[],
+        overrides: Partial<Record<SpecialUse.EditableType, string | null>>
+    ): Promise<SpecialUse.Mapping> {
+        const current = await this.resolve(accountId, mailboxes);
+        const paths = new Set(mailboxes.map((mb) => mb.path));
+
+        for (const type of SpecialUse.EDITABLE_TYPES) {
+            if (!(type in overrides)) continue;
+            const path = overrides[type];
+
+            if (path == null) {
+                // Clear the override → re-detect this single type.
+                const detected = SpecialUse.detectType(type, mailboxes);
+                if (detected) current[type] = detected;
+                else delete current[type];
+            } else if (paths.has(path)) {
+                current[type] = { path, source: 'user' };
+            }
+            // An unknown path is ignored here (the route validates it too).
+        }
+
+        await this.store(accountId, current);
+        return current;
+    }
+
+    static async deleteForAccount(accountId: number): Promise<void> {
+        await DB.instance().delete(DB.Tables.mailAccountSpecialUse).where(
+            eq(DB.Tables.mailAccountSpecialUse.mail_account_id, accountId)
+        );
+    }
+}

--- a/src/api/utils/services/specialUseService.ts
+++ b/src/api/utils/services/specialUseService.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { DB } from "../../../db";
 import { MailboxRessource } from "../../../utils/mails/ressources/mailbox";
+import type { IMAPAccount } from "../../../utils/mails/backends/imap";
 
 /**
  * Special-use folder detection and per-account persistence.
@@ -163,6 +164,22 @@ export class SpecialUseHandler {
     static async applyToMailboxes(accountId: number, mailboxes: MailboxRessource[]): Promise<MailboxRessource[]> {
         const mapping = await this.resolve(accountId, mailboxes);
         return SpecialUse.apply(mailboxes, mapping);
+    }
+
+    /**
+     * Resolve the account's Trash folder path from the persisted special-use
+     * mapping instead of re-guessing on every delete. The mapping is detected
+     * once (and kept fresh after folder mutations), so the common case is a
+     * single DB read with no IMAP round-trip. Only when no mapping has been
+     * persisted yet do we detect from the live folder list, persist it, and use
+     * that; if even detection finds nothing we fall back to the literal "Trash".
+     */
+    static async resolveTrashPath(accountId: number, imap: IMAPAccount): Promise<string> {
+        const stored = await this.getStored(accountId);
+        if (stored?.trash) return stored.trash.path;
+
+        const mapping = await this.resolve(accountId, await imap.getMailboxes());
+        return mapping.trash?.path ?? 'Trash';
     }
 
     /**

--- a/src/api/versions/v1/routes/mail-accounts/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/index.ts
@@ -166,6 +166,37 @@ router.post('/',
             owner_user_id: authContext.user_id
         }).returning().get().id;
 
+        // Detect the special-use folder mapping (drafts/sent/spam/trash/archive)
+        // once at creation so it is pre-filled by guessing and the user only has to
+        // correct the entries we got wrong. Best-effort: a create must still succeed
+        // if the IMAP server is unreachable — the mapping is then detected lazily on
+        // the first mailbox listing instead.
+        try {
+            const imap = MailClientsCache.createOrGetClientData({
+                id: result,
+                owner_user_id: authContext.user_id,
+                display_name: body.display_name,
+                is_default: body.is_default,
+
+                smtp_host: body.smtp_host,
+                smtp_port: body.smtp_port,
+                smtp_username: body.smtp_username,
+                smtp_password: body.smtp_password,
+                smtp_encryption: body.smtp_encryption,
+
+                imap_host: body.imap_host,
+                imap_port: body.imap_port,
+                imap_username: body.imap_username,
+                imap_password: body.imap_password,
+                imap_encryption: body.imap_encryption
+            } as MailAccountsModel.BASE).imap;
+
+            await imap.connect();
+            await SpecialUseHandler.resolve(result, await imap.getMailboxes());
+        } catch (e) {
+            Logger.error(`Failed to detect special-use folders for new mail account with ID ${result}`, e);
+        }
+
         return APIResponse.success(c, "Mail account created successfully", { id: result } satisfies MailAccountsModel.CreateMailAccount.Response);
     }
 );

--- a/src/api/versions/v1/routes/mail-accounts/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/index.ts
@@ -8,6 +8,8 @@ import { DOCS_TAGS } from "../../docs";
 import { router as mailboxesRouter } from "./mailboxes";
 import { router as identitiesRouter } from "./identities";
 import { router as searchRouter } from "./search";
+import { router as specialUseRouter } from "./special-use";
+import { SpecialUseHandler } from "../../../../utils/services/specialUseService";
 import { AuthHandler } from "../../../../utils/authHandler";
 import { validator } from "hono-openapi";
 import { MailClientsCache } from "../../../../../utils/mails/mail-clients-cache";
@@ -81,10 +83,11 @@ router.get('/',
                 try {
                     await imapClient.connect();
                     const mailboxes = await imapClient.getMailboxes();
+                    const withSpecialUse = await SpecialUseHandler.applyToMailboxes(account.id, mailboxes);
 
                     return {
                         ...mailAccount,
-                        mailboxes: mailboxes
+                        mailboxes: withSpecialUse
                     } satisfies MailAccountsModel.GetMailAccountByID.ResponseWithMailboxes;
                 } catch (e) {
                     Logger.error(`Failed to retrieve mailboxes for mail account with ID ${account.id}`, e);
@@ -272,10 +275,11 @@ router.get('/:mailAccountID',
             try {
                 await imapClient.connect();
                 const mailboxes = await imapClient.getMailboxes();
+                const withSpecialUse = await SpecialUseHandler.applyToMailboxes(mailAccount.id, mailboxes);
 
                 return APIResponse.success(c, "Mail account retrieved successfully", {
                     ...mailAccountResponse,
-                    mailboxes: mailboxes
+                    mailboxes: withSpecialUse
                 } satisfies MailAccountsModel.GetMailAccountByID.ResponseWithMailboxes);
                 
             } catch (e) {
@@ -413,6 +417,9 @@ router.delete('/:mailAccountID',
             eq(DB.Tables.mailIdentities.mail_account_id, mailAccount.id)
         );
 
+        // Drop the persisted special-use mapping for this account.
+        await SpecialUseHandler.deleteForAccount(mailAccount.id);
+
         await DB.instance().delete(DB.Tables.mailAccounts).where(
             eq(DB.Tables.mailAccounts.id, mailAccount.id)
         );
@@ -425,3 +432,4 @@ router.delete('/:mailAccountID',
 router.route("/:mailAccountID/mailboxes", mailboxesRouter);
 router.route("/:mailAccountID/identities", identitiesRouter);
 router.route("/:mailAccountID/search", searchRouter);
+router.route("/:mailAccountID/special-use", specialUseRouter);

--- a/src/api/versions/v1/routes/mail-accounts/mailboxes/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/mailboxes/index.ts
@@ -8,6 +8,7 @@ import { validator } from "hono-openapi";
 import { MailClientsCache } from "../../../../../../utils/mails/mail-clients-cache";
 import { Logger } from "../../../../../../utils/logger";
 import { MailboxService } from "../../../../../utils/services/maiboxService";
+import { SpecialUseHandler } from "../../../../../utils/services/specialUseService";
 import { router as mailsRouter } from "./mails";
 import { MailAccountsModel } from "../model";
 import { router as mailBulkActionsRouter } from "./mail-bulk-actions";
@@ -36,7 +37,11 @@ router.get('/',
             await imap.connect();
             const mailboxes = await imap.getMailboxes();
 
-            return APIResponse.success(c, "Mailboxes retrieved successfully", mailboxes satisfies MailboxesModel.GetAll.Response);
+            // Normalize specialUse from the persisted/detected mapping so the
+            // client can trust it without re-guessing.
+            const withSpecialUse = await SpecialUseHandler.applyToMailboxes(mailAccount.id, mailboxes);
+
+            return APIResponse.success(c, "Mailboxes retrieved successfully", withSpecialUse satisfies MailboxesModel.GetAll.Response);
         } catch (e) {
             Logger.error(`Failed to retrieve mailboxes`, e);
             return APIResponse.serverError(c, `Failed to retrieve mailboxes`);
@@ -74,6 +79,9 @@ router.post('/',
             if (!mailbox) {
                 return APIResponse.serverError(c, "Failed to verify created mailbox");
             }
+
+            // A new folder may be a special folder (or shift what is detected).
+            await SpecialUseHandler.resolve(mailAccount.id, await imap.getMailboxes());
 
             return APIResponse.successNoData(c, "Mailbox created successfully");
         } catch (e) {
@@ -181,6 +189,9 @@ router.put('/:mailboxPath',
             await imap.connect();
             await imap.renameMailbox(mailbox.path, body.path);
 
+            // Moving/renaming can invalidate a stored mapping that pointed here.
+            await SpecialUseHandler.resolve(mailAccount.id, await imap.getMailboxes());
+
             return APIResponse.successNoData(c, "Mailbox updated successfully");
         } catch (e) {
             Logger.error(`Failed to update mail mailbox with path ${mailbox.path}`, e);
@@ -213,6 +224,9 @@ router.delete('/:mailboxPath',
         try {
             await imap.connect();
             await imap.deleteMailbox(mailbox.path);
+
+            // A deleted folder may have been a mapped special folder.
+            await SpecialUseHandler.resolve(mailAccount.id, await imap.getMailboxes());
 
             return APIResponse.successNoData(c, "Mailbox deleted successfully");
         } catch (e) {

--- a/src/api/versions/v1/routes/mail-accounts/mailboxes/mail-bulk-actions/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/mailboxes/mail-bulk-actions/index.ts
@@ -6,6 +6,7 @@ import { validator } from "hono-openapi";
 import { APIResponse } from "../../../../../../utils/api-res";
 import { Logger } from "../../../../../../../utils/logger";
 import { MailClientsCache } from "../../../../../../../utils/mails/mail-clients-cache";
+import { SpecialUseHandler } from "../../../../../../utils/services/specialUseService";
 
 
 export const router = new Hono();
@@ -116,7 +117,8 @@ router.post('/delete',
             if (body.permanent) {
                 await imap.permanentlyDelete(mailbox.path, body.uids);
             } else {
-                await imap.moveToTrash(mailbox.path, body.uids);
+                const trashPath = await SpecialUseHandler.resolveTrashPath(mailAccount.id, imap);
+                await imap.moveToTrash(mailbox.path, body.uids, trashPath);
             }
 
             return APIResponse.success(c, "Mails deleted successfully", { success: true } satisfies MailBulkActionsModel.BulkDelete.Response);

--- a/src/api/versions/v1/routes/mail-accounts/mailboxes/mails/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/mailboxes/mails/index.ts
@@ -11,6 +11,7 @@ import { MailClientsCache } from "../../../../../../../utils/mails/mail-clients-
 import { Logger } from "../../../../../../../utils/logger";
 import { MailboxesModel } from "../model";
 import { MailboxService } from "../../../../../../utils/services/maiboxService";
+import { SpecialUseHandler } from "../../../../../../utils/services/specialUseService";
 import { SMTPAccount } from "../../../../../../../utils/mails/backends/smtp";
 import { MailRessource } from "../../../../../../../utils/mails/ressources/mail";
 import MailComposer from "nodemailer/lib/mail-composer";
@@ -247,7 +248,8 @@ router.put('/:mailUID',
                 newUid = latestMail ? latestMail.uid : undefined;
 
                 // Delete the old mail
-                await imap.moveToTrash(mailbox.path, [mailData.uid]);
+                const trashPath = await SpecialUseHandler.resolveTrashPath(mailAccount.id, imap);
+                await imap.moveToTrash(mailbox.path, [mailData.uid], trashPath);
             }
 
             return APIResponse.success(c, "Mail updated successfully", { success: true, newUid } satisfies MailsModel.Update.Response);
@@ -295,7 +297,8 @@ router.post('/:mailUID/send',
                 await imap.moveToMailbox(mailbox.path, [mailData.uid], 'Sent');
             } else if (body.deleteOriginal) {
                 // Only delete if not moving to Sent
-                await imap.moveToTrash(mailbox.path, [mailData.uid]);
+                const trashPath = await SpecialUseHandler.resolveTrashPath(mailAccount.id, imap);
+                await imap.moveToTrash(mailbox.path, [mailData.uid], trashPath);
             }
 
             return APIResponse.success(c, "Mail sent successfully", { 
@@ -437,7 +440,8 @@ router.delete('/:mailUID',
                 await imap.permanentlyDelete(mailbox.path, [mailData.uid]);
             } else {
                 // Move to trash
-                await imap.moveToTrash(mailbox.path, [mailData.uid]);
+                const trashPath = await SpecialUseHandler.resolveTrashPath(mailAccount.id, imap);
+                await imap.moveToTrash(mailbox.path, [mailData.uid], trashPath);
             }
 
             return APIResponse.success(c, "Mail deleted successfully", { success: true } satisfies MailsModel.Delete.Response);

--- a/src/api/versions/v1/routes/mail-accounts/special-use/index.ts
+++ b/src/api/versions/v1/routes/mail-accounts/special-use/index.ts
@@ -1,0 +1,88 @@
+import { Hono } from "hono";
+import { validator } from "hono-openapi";
+import { SpecialUseModel } from "./model";
+import { MailAccountsModel } from "../model";
+import { APIResponse } from "../../../../../utils/api-res";
+import { APIResponseSpec, APIRouteSpec } from "../../../../../utils/specHelpers";
+import { DOCS_TAGS } from "../../../docs";
+import { MailClientsCache } from "../../../../../../utils/mails/mail-clients-cache";
+import { SpecialUseHandler, SpecialUse } from "../../../../../utils/services/specialUseService";
+import { Logger } from "../../../../../../utils/logger";
+
+export const router = new Hono();
+
+router.get('/',
+
+    APIRouteSpec.authenticated({
+        summary: "Get special-use folder mapping",
+        description: "Retrieve the resolved special-use folder mapping (drafts/sent/spam/trash/archive) for the account. Detected and persisted by the backend; user overrides are preserved.",
+        tags: [DOCS_TAGS.MAIL_ACCOUNTS.MAILBOXES],
+
+        responses: APIResponseSpec.describeBasic(
+            APIResponseSpec.success("Special-use mapping retrieved successfully", SpecialUseModel.Get.Response)
+        )
+    }),
+
+    async (c) => {
+        // @ts-ignore
+        const mailAccount = c.get("mailAccount") as MailAccountsModel.BASE;
+
+        const imap = MailClientsCache.createOrGetClientData(mailAccount).imap;
+
+        try {
+            await imap.connect();
+            const mailboxes = await imap.getMailboxes();
+            const mapping = await SpecialUseHandler.resolve(mailAccount.id, mailboxes);
+
+            return APIResponse.success(c, "Special-use mapping retrieved successfully", mapping satisfies SpecialUseModel.Get.Response);
+        } catch (e) {
+            Logger.error(`Failed to retrieve special-use mapping for mail account ${mailAccount.id}`, e);
+            return APIResponse.serverError(c, "Failed to retrieve special-use mapping");
+        }
+    }
+);
+
+router.put('/',
+
+    APIRouteSpec.authenticated({
+        summary: "Update special-use folder mapping",
+        description: "Override which folders are the account's special folders. Each type maps to a folder path, or null to clear the override and revert to auto-detection.",
+        tags: [DOCS_TAGS.MAIL_ACCOUNTS.MAILBOXES],
+
+        responses: APIResponseSpec.describeWithWrongInputs(
+            APIResponseSpec.success("Special-use mapping updated successfully", SpecialUseModel.Update.Response)
+        )
+    }),
+
+    validator("json", SpecialUseModel.Update.Body),
+
+    async (c) => {
+        const body = c.req.valid("json");
+
+        // @ts-ignore
+        const mailAccount = c.get("mailAccount") as MailAccountsModel.BASE;
+
+        const imap = MailClientsCache.createOrGetClientData(mailAccount).imap;
+
+        try {
+            await imap.connect();
+            const mailboxes = await imap.getMailboxes();
+            const paths = new Set(mailboxes.map((mb) => mb.path));
+
+            // Reject overrides that point at a folder that doesn't exist.
+            for (const type of SpecialUse.EDITABLE_TYPES) {
+                const path = body[type];
+                if (path != null && !paths.has(path)) {
+                    return APIResponse.badRequest(c, `No folder found at path "${path}" for special-use "${type}"`);
+                }
+            }
+
+            const mapping = await SpecialUseHandler.setOverrides(mailAccount.id, mailboxes, body);
+
+            return APIResponse.success(c, "Special-use mapping updated successfully", mapping satisfies SpecialUseModel.Update.Response);
+        } catch (e) {
+            Logger.error(`Failed to update special-use mapping for mail account ${mailAccount.id}`, e);
+            return APIResponse.serverError(c, "Failed to update special-use mapping");
+        }
+    }
+);

--- a/src/api/versions/v1/routes/mail-accounts/special-use/model.ts
+++ b/src/api/versions/v1/routes/mail-accounts/special-use/model.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { SpecialUse } from "../../../../../utils/services/specialUseService";
+
+export namespace SpecialUseModel {
+
+    const Entry = z.object({
+        // Real IMAP path of the folder assigned to this special-use type.
+        path: z.string(),
+        // Where the assignment came from: server flag, name heuristic, or the user.
+        source: z.enum(['flag', 'guess', 'user']),
+    });
+
+    // Full resolved mapping (type -> entry). Every type is optional; a missing
+    // type means no folder of that kind was detected.
+    export const Mapping = z.object({
+        inbox: Entry.optional(),
+        drafts: Entry.optional(),
+        sent: Entry.optional(),
+        spam: Entry.optional(),
+        trash: Entry.optional(),
+        archive: Entry.optional(),
+    });
+    export type Mapping = z.infer<typeof Mapping>;
+
+    export namespace Get {
+        export const Response = Mapping;
+        export type Response = z.infer<typeof Response>;
+    }
+
+    export namespace Update {
+        // Each editable type maps to a folder path, or null to clear the override
+        // and fall back to auto-detection. Inbox is fixed and not editable.
+        export const Body = z.object({
+            drafts: z.string().nullable().optional(),
+            sent: z.string().nullable().optional(),
+            spam: z.string().nullable().optional(),
+            trash: z.string().nullable().optional(),
+            archive: z.string().nullable().optional(),
+        });
+        export type Body = z.infer<typeof Body>;
+
+        export const Response = Mapping;
+        export type Response = z.infer<typeof Response>;
+    }
+
+    // Compile-time guard: the model's editable keys must match the service's.
+    const _editableKeys: Record<SpecialUse.EditableType, true> = {
+        drafts: true, sent: true, spam: true, trash: true, archive: true,
+    };
+    void _editableKeys;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -102,6 +102,7 @@ export namespace DB.Tables {
 
     export const metadata = TableSchema.metadata;
     export const userPreferences = TableSchema.userPreferences;
+    export const mailAccountSpecialUse = TableSchema.mailAccountSpecialUse;
 }
 
 export namespace DB.Models {

--- a/src/db/schema/sqlite.ts
+++ b/src/db/schema/sqlite.ts
@@ -133,3 +133,19 @@ export const userPreferences = sqliteTable('user_preferences', {
 }, (table) => [
     uniqueIndex('user_preferences_user_id_key_unique').on(table.user_id, table.key)
 ]);
+
+/**
+ * Persisted special-use folder mapping per mail account. The backend detects
+ * these once (IMAP \\Flag → name heuristic) and stores the result so neither it
+ * nor the client re-guesses on every request; users can override individual
+ * entries. One row per account; `data` is `{ [type]: { path, source } }`.
+ */
+export const mailAccountSpecialUse = sqliteTable('mail_account_special_use', {
+    id: integer().primaryKey({ autoIncrement: true }),
+    mail_account_id: integer().notNull().references(() => mailAccounts.id),
+    created_at: SQLUtils.getCreatedAtColumn("sqlite"),
+
+    data: text({ mode: 'json' }).$type<Record<string, { path: string; source: 'flag' | 'guess' | 'user' }>>().notNull()
+}, (table) => [
+    uniqueIndex('mail_account_special_use_account_unique').on(table.mail_account_id)
+]);

--- a/src/utils/mails/backends/imap.ts
+++ b/src/utils/mails/backends/imap.ts
@@ -318,54 +318,12 @@ export class IMAPAccount {
     }
 
     /**
-     * Resolves the account's Trash mailbox path, preferring the server-advertised
-     * `\Trash` special-use folder over name heuristics (which only cover common
-     * naming conventions like Gmail's `[Gmail]/Trash`).
+     * Moves messages to the given Trash folder. The path is resolved by the
+     * caller from the account's persisted special-use mapping
+     * ({@link SpecialUseHandler.resolveTrashPath}) rather than re-guessed here on
+     * every delete.
      */
-    async resolveTrashPath(): Promise<string> {
-        const mailboxes = await this.client.list();
-
-        // 1. Server-advertised special-use is the most reliable signal and should
-        //    always win (it maps to whatever the provider calls its trash folder,
-        //    e.g. a localized name or a hierarchy like "[Gmail]/Trash").
-        const specialUseTrash = mailboxes.find(mb => mb.specialUse === '\\Trash');
-        if (specialUseTrash) return specialUseTrash.path;
-
-        // 2. Fall back to matching the folder's *leaf* name (so hierarchy prefixes
-        //    like "INBOX.Trash" or "[Gmail]/Trash" still match) against common
-        //    English and localized trash names. Matching only the literal full path
-        //    before — and only a couple of English names — meant many real servers
-        //    (e.g. German "Papierkorb", or dovecot's "INBOX.Trash") fell through to
-        //    the "Trash" default below and messages never landed in the real trash.
-        const trashNames = new Set([
-            'trash', 'deleted', 'deleted items', 'deleted messages', 'bin', 'recycle bin',
-            'papierkorb',   // de
-            'corbeille',    // fr
-            'papelera',     // es
-            'cestino',      // it
-            'prullenbak',   // nl
-            'lixeira',      // pt
-            'kosz',         // pl
-            'papperskorg',  // sv
-        ]);
-
-        const leafName = (mb: { path: string; delimiter?: string }): string => {
-            const delimiter = mb.delimiter || '/';
-            return (mb.path.split(delimiter).pop() ?? mb.path).toLowerCase();
-        };
-
-        const nameMatch = mailboxes.find(mb =>
-            trashNames.has(leafName(mb)) || trashNames.has(mb.path.toLowerCase())
-        );
-        if (nameMatch) return nameMatch.path;
-
-        // 3. Last resort: the literal "Trash" (the server may auto-create it).
-        return 'Trash';
-    }
-
-    async moveToTrash(mailbox: string, uids: number[]) {
-        const trashPath = await this.resolveTrashPath();
-
+    async moveToTrash(mailbox: string, uids: number[], trashPath: string) {
         // Deleting from within the Trash folder can't move anywhere further, and a
         // move onto itself would be a silent no-op that looks successful — treat it
         // as a permanent delete instead.

--- a/tests/api.routes.test.ts
+++ b/tests/api.routes.test.ts
@@ -11,6 +11,9 @@ import { AccountPreferencesModel } from "../src/api/versions/v1/routes/account/p
 import { MailAccountsModel } from "../src/api/versions/v1/routes/mail-accounts/model";
 import { MailIdentitiesModel } from "../src/api/versions/v1/routes/mail-accounts/identities/model";
 import { MailboxesModel } from "../src/api/versions/v1/routes/mail-accounts/mailboxes/model";
+import { SpecialUseModel } from "../src/api/versions/v1/routes/mail-accounts/special-use/model";
+import { SpecialUse } from "../src/api/utils/services/specialUseService";
+import { MailboxRessource } from "../src/utils/mails/ressources/mailbox";
 import { IMAPAccount } from "../src/utils/mails/backends/imap";
 import { MailAccountEncryption } from "../src/utils/crypto/mailCrypt";
 import { MailsModel } from "../src/api/versions/v1/routes/mail-accounts/mailboxes/mails/model";
@@ -2769,5 +2772,201 @@ describe("Docs Routes", async () => {
     test("GET /docs/v1 returns 404 if disabled", async () => {
 
         await makeAPIRequest(`/docs/v1`, {}, 404);
+    });
+});
+// Fabricate a mailbox for the pure-function unit tests below.
+function fakeMailbox(path: string, specialUse?: string, delimiter = "/"): MailboxRessource {
+    return new MailboxRessource({
+        name: path.split(delimiter).pop() || path,
+        path,
+        delimiter,
+        parent: [],
+        parentPath: "",
+        flags: [],
+        specialUse,
+        status: { messages: 0, unseen: 0, recent: 0 },
+    });
+}
+
+describe("SpecialUse detection (unit)", async () => {
+
+    test("detectType prefers the server SPECIAL-USE flag", () => {
+        const boxes = [fakeMailbox("Sent", "\\Sent"), fakeMailbox("Something Else")];
+        expect(SpecialUse.detectType("sent", boxes)).toEqual({ path: "Sent", source: "flag" });
+    });
+
+    test("detectType falls back to (localized) leaf-name heuristics", () => {
+        // German "Gesendet" with no flag should still resolve as Sent.
+        const boxes = [fakeMailbox("INBOX.Gesendet", undefined, ".")];
+        expect(SpecialUse.detectType("sent", boxes)).toEqual({ path: "INBOX.Gesendet", source: "guess" });
+    });
+
+    test("detectType returns undefined when nothing matches", () => {
+        const boxes = [fakeMailbox("Random"), fakeMailbox("Another")];
+        expect(SpecialUse.detectType("archive", boxes)).toBeUndefined();
+    });
+
+    test("reconcile from scratch resolves the whole mapping and omits missing types", () => {
+        const boxes = [
+            fakeMailbox("INBOX"),
+            fakeMailbox("Sent", "\\Sent"),
+            fakeMailbox("Drafts", "\\Drafts"),
+            fakeMailbox("Trash"),   // by name only
+        ];
+        const mapping = SpecialUse.reconcile(null, boxes);
+        expect(mapping.inbox?.path).toBe("INBOX");
+        expect(mapping.sent).toEqual({ path: "Sent", source: "flag" });
+        expect(mapping.drafts).toEqual({ path: "Drafts", source: "flag" });
+        expect(mapping.trash).toEqual({ path: "Trash", source: "guess" });
+        expect(mapping.spam).toBeUndefined();
+        expect(mapping.archive).toBeUndefined();
+    });
+
+    test("reconcile keeps a still-valid user override but re-detects the rest", () => {
+        const boxes = [fakeMailbox("Custom"), fakeMailbox("Sent", "\\Sent"), fakeMailbox("Trash", "\\Trash")];
+        const existing: SpecialUse.Mapping = {
+            drafts: { path: "Custom", source: "user" },
+            sent: { path: "Old", source: "flag" },
+        };
+        const result = SpecialUse.reconcile(existing, boxes);
+        expect(result.drafts).toEqual({ path: "Custom", source: "user" });   // preserved
+        expect(result.sent).toEqual({ path: "Sent", source: "flag" });        // re-detected
+        expect(result.trash).toEqual({ path: "Trash", source: "flag" });      // newly detected
+    });
+
+    test("reconcile drops a user override whose folder no longer exists", () => {
+        const boxes = [fakeMailbox("Sent", "\\Sent")];
+        const existing: SpecialUse.Mapping = { drafts: { path: "GoneFolder", source: "user" } };
+        const result = SpecialUse.reconcile(existing, boxes);
+        expect(result.drafts).toBeUndefined();
+    });
+
+    test("apply writes mapped flags and clears stray managed flags", () => {
+        const boxes = [
+            fakeMailbox("Sent", "\\Sent"),
+            fakeMailbox("MyDrafts"),
+            fakeMailbox("OldDrafts", "\\Drafts"),
+        ];
+        const mapping: SpecialUse.Mapping = {
+            sent: { path: "Sent", source: "flag" },
+            drafts: { path: "MyDrafts", source: "user" },
+        };
+        const applied = SpecialUse.apply(boxes, mapping);
+        expect(applied.find((mb) => mb.path === "Sent")?.specialUse).toBe("\\Sent");
+        expect(applied.find((mb) => mb.path === "MyDrafts")?.specialUse).toBe("\\Drafts");
+        // OldDrafts carried \Drafts but isn't the mapped drafts folder -> cleared.
+        expect(applied.find((mb) => mb.path === "OldDrafts")?.specialUse).toBeUndefined();
+    });
+});
+
+describe("Mail Special-Use Routes", async () => {
+
+    let specialUseUser: SeededUser;
+    let session_token: string;
+    let mailAccountID: number;
+
+    const connectionSettings = {
+        smtp_host: "127.0.0.1", smtp_port: 11125, smtp_encryption: "NONE",
+        smtp_username: "testuser", smtp_password: "testpass",
+        imap_host: "127.0.0.1", imap_port: 11143, imap_encryption: "NONE",
+        imap_username: "testuser", imap_password: "testpass",
+    } as const;
+
+    beforeAll(async () => {
+        specialUseUser = await seedUser("user", { username: "specialuseuser" }, "SpecialP@ss1");
+        session_token = await seedSession(specialUseUser.id).then(s => s.token);
+
+        const encryptedSMTPData = MailAccountEncryption.encryptSMTPData({
+            host: connectionSettings.smtp_host, port: connectionSettings.smtp_port,
+            username: connectionSettings.smtp_username, password: connectionSettings.smtp_password,
+            useSSL: connectionSettings.smtp_encryption,
+        });
+        const encryptedIMAPData = MailAccountEncryption.encryptIMAPData({
+            host: connectionSettings.imap_host, port: connectionSettings.imap_port,
+            username: connectionSettings.imap_username, password: connectionSettings.imap_password,
+            useSSL: connectionSettings.imap_encryption,
+        });
+        if (!encryptedSMTPData || !encryptedIMAPData) throw new Error("Failed to encrypt mail account data");
+
+        mailAccountID = DB.instance().insert(DB.Tables.mailAccounts).values({
+            owner_user_id: specialUseUser.id,
+            display_name: "Special-Use Test Account",
+            smtp_encrypted_connection_data: encryptedSMTPData,
+            imap_encrypted_connection_data: encryptedIMAPData,
+        }).returning().get().id;
+    });
+
+    test("GET /special-use auto-detects and persists the mapping", async () => {
+        const data = await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {
+            authToken: session_token,
+            expectedBodySchema: SpecialUseModel.Get.Response,
+        });
+
+        // The mock server advertises \Sent / \Drafts / \Junk / \Trash flags.
+        expect(data.sent).toEqual({ path: "Sent", source: "flag" });
+        expect(data.drafts).toEqual({ path: "Drafts", source: "flag" });
+        expect(data.spam).toEqual({ path: "Spam", source: "flag" });
+        expect(data.trash).toEqual({ path: "Trash", source: "flag" });
+        expect(data.inbox?.path).toBe("INBOX");
+        // No archive folder exists on the mock server.
+        expect(data.archive).toBeUndefined();
+
+        // The resolved mapping was persisted (one row for the account).
+        const rows = DB.instance().select().from(DB.Tables.mailAccountSpecialUse).where(
+            eq(DB.Tables.mailAccountSpecialUse.mail_account_id, mailAccountID)
+        ).all();
+        expect(rows.length).toBe(1);
+    });
+
+    test("PUT /special-use overrides a mapping and marks it as user-set", async () => {
+        const data = await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {
+            method: "PUT",
+            authToken: session_token,
+            body: { drafts: "INBOX/Work" },
+            expectedBodySchema: SpecialUseModel.Update.Response,
+        });
+        expect(data.drafts).toEqual({ path: "INBOX/Work", source: "user" });
+
+        // Persisted and returned by a subsequent GET.
+        const after = await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {
+            authToken: session_token,
+            expectedBodySchema: SpecialUseModel.Get.Response,
+        });
+        expect(after.drafts).toEqual({ path: "INBOX/Work", source: "user" });
+    });
+
+    test("mailbox listing reflects the override and clears the stray flag", async () => {
+        const data = await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/mailboxes`, {
+            authToken: session_token,
+            expectedBodySchema: MailboxesModel.GetAll.Response,
+        });
+        // The overridden folder now carries the \Drafts flag...
+        expect(data.find(mb => mb.path === "INBOX/Work")?.specialUse).toBe("\\Drafts");
+        // ...and the server's original Drafts folder no longer does.
+        expect(data.find(mb => mb.path === "Drafts")?.specialUse).toBeUndefined();
+        // Sent is untouched.
+        expect(data.find(mb => mb.path === "Sent")?.specialUse).toBe("\\Sent");
+    });
+
+    test("PUT /special-use with null reverts a type to auto-detection", async () => {
+        const data = await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {
+            method: "PUT",
+            authToken: session_token,
+            body: { drafts: null },
+            expectedBodySchema: SpecialUseModel.Update.Response,
+        });
+        expect(data.drafts).toEqual({ path: "Drafts", source: "flag" });
+    });
+
+    test("PUT /special-use rejects a path that doesn't exist", async () => {
+        await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {
+            method: "PUT",
+            authToken: session_token,
+            body: { sent: "INBOX/DoesNotExist" },
+        }, 400);
+    });
+
+    test("GET /special-use without auth fails", async () => {
+        await makeAPIRequest(`/v1/mail-accounts/${mailAccountID}/special-use`, {}, 401);
     });
 });


### PR DESCRIPTION
Adds a per-account special-use folder mapping (drafts/sent/spam/trash/ archive) that the backend detects once (IMAP \Flag -> multilingual name heuristic), stores in a new mail_account_special_use table, and reuses so neither it nor the client re-guesses on every request. Users can override individual mappings; overrides survive re-detection while their folder exists. Mailbox listings now return the resolved specialUse, and the mapping is re-detected after folder create/rename/delete and dropped on account delete. Exposes GET/PUT /mail-accounts/:id/special-use.